### PR TITLE
Add release-readiness GitHub Actions verification

### DIFF
--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -1,0 +1,38 @@
+name: Release readiness
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Verify package
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check formatting
+        run: npm run format:check
+
+      - name: Run tests
+        run: npm test
+
+      - name: Build package
+        run: npm run build


### PR DESCRIPTION
## Background

Closes #5. The release-readiness tracker #3 identified that this package has local verification commands but no GitHub Actions gate for PRs or `main`. This PR adds the focused CI check before broader npm packaging/release work continues.

## Changes

- Add `.github/workflows/release-readiness.yml`.
- Run on pull requests and pushes to `main`.
- Use Node.js 22 with npm cache.
- Gate the package with `npm ci`, `npm run format:check`, `npm test`, and `npm run build`.

## Local validation

- `npm ci` passed; npm reported 0 vulnerabilities.
- `npm run format:check` passed.
- `npm test` passed: 5 files, 88 tests.
- `npm run build` passed.

## Risks / follow-up

- This intentionally does not publish packages, tag releases, or deploy anything.
- Package contents and reproducible pack/release metadata remain tracked separately in #6 and #7.
- The PR Actions result still needs to be checked after GitHub runs the new workflow on this branch.
