### PR TITLE
Exclude test output from npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "gh-agent": "./dist/cli.js"
   },
   "files": [
-    "dist"
+    "dist",
+    "!dist/**/*.test.*",
+    "!dist/test"
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",


### PR DESCRIPTION
## Background

Closes #6. The release-readiness review found that `npm pack --dry-run` was shipping compiled test files and test helpers from `dist/`. That increases package size and exposes non-runtime internals to npm users.

## Change

- Keeps the existing runtime `dist` allowlist.
- Adds npm `files` exclusions for `dist/**/*.test.*` and `dist/test`.
- Leaves source tests and local test execution unchanged.

## Package contents before/after

Before this change, `npm pack --dry-run` included compiled test output such as:
- `dist/commands/commands.test.js` and maps/declarations
- `dist/core/*.test.js` and maps/declarations
- `dist/test/test-helpers.js` and maps/declarations

After this change:
- `npm pack --dry-run` reports 114 files instead of 138.
- Package size drops from 81.4 kB to 54.8 kB.
- Unpacked size drops from 495.6 kB to 302.7 kB.
- A Node-based package listing check found no packaged test-file matches.

## Validation

- `npm ci`
- `npm run format:check`
- `npm test` (5 files / 88 tests)
- `npm run build`
- `npm pack --dry-run`
- `node -e "const {execFileSync}=require('node:child_process'); const data=JSON.parse(execFileSync('npm',['pack','--dry-run','--json'],{encoding:'utf8'})); const matches=data[0].files.map(f=>f.path).filter(p=>/(^|\/)(test|.*\.test\.)/.test(p)); if(matches.length){console.log(matches.join('\n')); process.exit(1)} console.log('No packaged test files matched.');"`

## Risk

Low. The change only affects the npm package allowlist. Runtime entry points such as `dist/cli.js`, command modules, core modules, declarations, and source maps remain included.