### PR TITLE
Define reproducible npm release path

### DIFF
--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -28,11 +28,5 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Check formatting
-        run: npm run format:check
-
-      - name: Run tests
-        run: npm test
-
-      - name: Build package
-        run: npm run build
+      - name: Check release package
+        run: npm run release:check

--- a/docs/release/npm-release.md
+++ b/docs/release/npm-release.md
@@ -1,0 +1,55 @@
+# npm release path
+
+This project keeps `dist/` out of git, so every npm package must be built from the
+current checkout before it is packed or published.
+
+## Maintainer check
+
+Run this from a clean checkout before opening or approving a release PR:
+
+```bash
+npm ci
+npm run release:check
+```
+
+`npm run release:check` is the single local and CI release-readiness path. It
+runs formatting checks, tests, a TypeScript build, and `npm pack --dry-run` so the
+tarball contents can be inspected before publication.
+
+The package also defines lifecycle guards:
+
+- `prepack` rebuilds `dist/` immediately before `npm pack` creates a tarball.
+- `prepublishOnly` runs `release:check` before `npm publish`.
+
+These guards reduce the risk of publishing stale local build output, but
+maintainers should still use `npm run release:check` as the explicit review
+command because it prints the dry-run package manifest.
+
+## Publication decisions still owned by maintainers
+
+Confirm these before the first public npm publication:
+
+- Package name: `gh-agent` is the current package name. Confirm npm name
+  availability and whether a scoped name such as `@heoh/gh-agent` is preferred.
+- License: `MIT` is currently declared in `package.json`. Confirm this is the
+  intended public license.
+- Versioning: `0.1.0` is currently declared. Confirm whether the first public
+  release should start at `0.1.0` and use semver from that point.
+- Positioning: `TypeScript-based CLI package for gh-agent.` is the current npm
+  description. Confirm the public README and npm description before publication.
+
+## Future GitHub release automation
+
+Manual workflow or release-tag based publishing should call the same
+`npm run release:check` path before `npm publish`. Keep that automation in a
+separate PR so the first step remains reviewable: define and verify the package
+that would be published.
+
+Recommended follow-up options:
+
+- Manual workflow: `workflow_dispatch` accepts a version input, validates the
+  working tree, runs `npm version`, runs `npm run release:check`, and publishes.
+- Tag workflow: a `vX.Y.Z` tag or GitHub Release triggers validation that the tag
+  matches `package.json`, then runs `npm run release:check` and publishes.
+- Combined workflow: support both entry points, with a guard that prevents
+  publishing the same package version twice.

--- a/package.json
+++ b/package.json
@@ -19,7 +19,10 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "format": "prettier --write .",
-    "format:check": "prettier --check ."
+    "format:check": "prettier --check .",
+    "release:check": "npm run format:check && npm test && npm run build && npm pack --dry-run",
+    "prepack": "npm run build",
+    "prepublishOnly": "npm run release:check"
   },
   "keywords": [
     "cli",


### PR DESCRIPTION
## Background

Closes #7. The package depends on generated `dist/` output, so release review needs one reproducible command path that builds, validates, and inspects the package before publication. The owner also confirmed that GitHub manual/tag-based publish automation should be captured as a follow-up design note, not implemented in this slice.

## Changes

- Added `npm run release:check` as the shared local/CI path: format check, tests, build, and `npm pack --dry-run`.
- Added npm lifecycle guards: `prepack` rebuilds before pack, and `prepublishOnly` runs `release:check` before publish.
- Updated Release readiness CI to call `npm run release:check`, so PRs and main pushes inspect the pack manifest.
- Added `docs/release/npm-release.md` with maintainer commands, publication decisions still requiring owner confirmation, and future manual/tag publish automation options.

## Verification

- `npm ci`
- `npm run release:check`
  - 5 test files / 88 tests passed
  - `npm pack --dry-run` produced `gh-agent-0.1.0.tgz` with 114 files, 54.8 kB package size, 302.9 kB unpacked size

## Risks and follow-up

- `README.md` is still empty and remains tracked separately by #4 before public npm publication.
- The documented owner decisions are still open before publish: npm package name/scoping, license intent, initial versioning, and public positioning.
- Actual GitHub Actions npm publish automation is intentionally deferred to a separate issue/PR after this release path is accepted.
