### PR TITLE
Add manual npm publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Package version to publish, matching package.json'
+        description: 'Package version to publish, matching package.json (example: 0.1.0)'
         required: true
         type: string
 

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,64 @@
+name: Publish package to npm
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Package version to publish, matching package.json'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    name: Publish npm package
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Require main branch
+        run: |
+          if [ "$GITHUB_REF" != "refs/heads/main" ]; then
+            echo "This workflow must run from main. Current ref: $GITHUB_REF"
+            exit 1
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          registry-url: 'https://registry.npmjs.org'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Validate requested version
+        run: |
+          package_name="$(node -p "require('./package.json').name")"
+          package_version="$(node -p "require('./package.json').version")"
+          requested_version="${{ inputs.version }}"
+
+          if [ "$package_version" != "$requested_version" ]; then
+            echo "Requested version $requested_version does not match package.json version $package_version."
+            exit 1
+          fi
+
+          if npm view "$package_name@$package_version" version --registry=https://registry.npmjs.org >/tmp/npm-published-version 2>/dev/null; then
+            echo "$package_name@$package_version is already published to npm."
+            exit 1
+          fi
+
+          echo "Validated $package_name@$package_version for publication."
+
+      - name: Check release package
+        run: npm run release:check
+
+      - name: Publish to npm
+        run: npm publish

--- a/docs/release/npm-release.md
+++ b/docs/release/npm-release.md
@@ -42,7 +42,7 @@ Confirm these before the first public npm publication:
 
 Maintainers can publish from GitHub Actions with the manual `Publish package to
 npm` workflow. Run it from the `main` branch and enter the exact version already
-committed in `package.json`.
+committed in `package.json`, such as `0.1.0`.
 
 The workflow intentionally does not edit `package.json`, create commits, create
 tags, or publish from release events. Version bumps should happen in a reviewed

--- a/docs/release/npm-release.md
+++ b/docs/release/npm-release.md
@@ -38,18 +38,55 @@ Confirm these before the first public npm publication:
 - Positioning: `TypeScript-based CLI package for gh-agent.` is the current npm
   description. Confirm the public README and npm description before publication.
 
-## Future GitHub release automation
+## GitHub npm publication
 
-Manual workflow or release-tag based publishing should call the same
-`npm run release:check` path before `npm publish`. Keep that automation in a
-separate PR so the first step remains reviewable: define and verify the package
-that would be published.
+Maintainers can publish from GitHub Actions with the manual `Publish package to
+npm` workflow. Run it from the `main` branch and enter the exact version already
+committed in `package.json`.
 
-Recommended follow-up options:
+The workflow intentionally does not edit `package.json`, create commits, create
+tags, or publish from release events. Version bumps should happen in a reviewed
+PR first; the manual workflow only validates and publishes the version that is
+already on `main`.
 
-- Manual workflow: `workflow_dispatch` accepts a version input, validates the
-  working tree, runs `npm version`, runs `npm run release:check`, and publishes.
-- Tag workflow: a `vX.Y.Z` tag or GitHub Release triggers validation that the tag
-  matches `package.json`, then runs `npm run release:check` and publishes.
-- Combined workflow: support both entry points, with a guard that prevents
-  publishing the same package version twice.
+The workflow guards the publish step by:
+
+- Failing unless the selected workflow ref is `main`.
+- Failing unless the `workflow_dispatch` version input equals
+  `package.json#version`.
+- Failing if `npm view <package>@<version>` finds that the package version is
+  already published.
+- Running `npm run release:check` before `npm publish`.
+
+### npm trusted publishing setup
+
+Preferred authentication is npm trusted publishing, not a long-lived npm token.
+Configure the package on npmjs.com with this trusted publisher:
+
+- Publisher: GitHub Actions
+- Organization or user: `heoh`
+- Repository: `gh-agent`
+- Workflow filename: `npm-publish.yml`
+- Environment name: leave unset unless the workflow is later changed to use a
+  matching GitHub environment
+
+The workflow grants `id-token: write` and uses a GitHub-hosted runner with Node
+24 so npm can authenticate with OIDC during `npm publish`.
+
+### Token fallback
+
+If trusted publishing is unavailable for the first release, add an `NPM_TOKEN`
+repository secret and change the publish step to pass it as `NODE_AUTH_TOKEN`.
+Use `npm publish --provenance` for token-based publishing so the package still
+gets provenance metadata.
+
+```yaml
+- name: Publish to npm
+  run: npm publish --provenance
+  env:
+    NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+```
+
+Keep tag or GitHub Release triggered publication as a separate follow-up. That
+flow needs additional decisions for version bump PRs, bump commits, tag ordering,
+and duplicate-publish recovery.


### PR DESCRIPTION
## Background

Closes #12.

The owner approved the manual `workflow_dispatch` direction after the #7/#11 release path was merged. This PR keeps npm publication explicit: version bumps stay in reviewed PRs, and GitHub Actions only validates and publishes the version already committed on `main`.

## Changes

- Adds `.github/workflows/npm-publish.yml` as a manual npm publish workflow.
- Requires the workflow to run from `main`.
- Accepts a required `version` input and fails if it does not match `package.json#version`.
- Checks npm before publishing and fails if `<package>@<version>` is already published.
- Runs `npm run release:check` before `npm publish`.
- Documents the maintainer release flow, npm trusted publishing setup, token fallback, and why tag/release-triggered publishing remains out of scope.

## Authentication choice

Preferred path is npm trusted publishing/OIDC:

- npm trusted publisher: GitHub Actions
- Organization/user: `heoh`
- Repository: `gh-agent`
- Workflow filename: `npm-publish.yml`
- Environment: unset unless this workflow later uses a matching GitHub environment

The workflow grants `id-token: write` and uses Node 24. npm documents trusted publishing as requiring npm CLI 11.5.1+ and Node 22.14.0+; Node 24 keeps this workflow on that path. npm also says trusted publishing automatically generates provenance for GitHub Actions publishes. Token fallback is documented separately with `NPM_TOKEN` and `npm publish --provenance`.

References:

- npm trusted publishing: https://docs.npmjs.com/trusted-publishers/
- GitHub npm package publishing guide: https://docs.github.com/actions/publishing-packages/publishing-nodejs-packages

## Validation

Local commands:

```bash
npm run format
npm run release:check
git diff --check
npm view gh-agent@0.1.0 version --registry=https://registry.npmjs.org
```

Results:

- `npm run release:check` passed: Prettier check, 5 test files / 88 tests, TypeScript build, and `npm pack --dry-run`.
- Dry-run pack still contains 114 files, 54.8 kB package size, and 302.9 kB unpacked size.
- `git diff --check` passed.
- `npm view gh-agent@0.1.0 version` returned npm `E404`, so the duplicate-publish guard should not block the current `0.1.0` first-release candidate.

## Risks / follow-up

- Maintainers must configure npm trusted publishing before the workflow can publish without `NPM_TOKEN`.
- Package metadata decisions from `docs/release/npm-release.md` still apply before first public publication: package name, license, first version, and public README/description.
- Tag or GitHub Release triggered publication remains a separate future decision because it needs version bump PR, bump commit, tag ordering, and duplicate-publish recovery policy.
