### PR TITLE
Add prepare release PR workflow

### DIFF
--- a/.github/workflows/prepare-release-pr.yml
+++ b/.github/workflows/prepare-release-pr.yml
@@ -1,0 +1,132 @@
+name: Prepare release PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Package version for the release PR (example: 0.2.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  prepare:
+    name: Prepare version bump PR
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Require main branch
+        run: |
+          if [ "$GITHUB_REF" != "refs/heads/main" ]; then
+            echo "This workflow must run from main. Current ref: $GITHUB_REF"
+            exit 1
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Validate requested version
+        id: version
+        run: |
+          requested_version="${{ inputs.version }}"
+          current_version="$(node -p "require('./package.json').version")"
+          package_name="$(node -p "require('./package.json').name")"
+
+          if [ "$requested_version" != "$(printf '%s' "$requested_version" | xargs)" ]; then
+            echo "Version input must not include leading or trailing whitespace."
+            exit 1
+          fi
+
+          if ! printf '%s' "$requested_version" | grep -Eq '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'; then
+            echo "Version must be a SemVer value without a leading v, for example 0.2.0."
+            exit 1
+          fi
+
+          if [ "$requested_version" = "$current_version" ]; then
+            echo "Requested version already matches package.json: $current_version"
+            exit 1
+          fi
+
+          if npm view "$package_name@$requested_version" version --registry=https://registry.npmjs.org >/tmp/npm-published-version 2>/dev/null; then
+            echo "$package_name@$requested_version is already published to npm."
+            exit 1
+          fi
+
+          echo "current_version=$current_version" >> "$GITHUB_OUTPUT"
+          echo "package_name=$package_name" >> "$GITHUB_OUTPUT"
+          echo "version=$requested_version" >> "$GITHUB_OUTPUT"
+
+      - name: Update package version
+        run: npm version --no-git-tag-version "${{ steps.version.outputs.version }}"
+
+      - name: Check release package
+        run: npm run release:check
+
+      - name: Create or update release PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CURRENT_VERSION: ${{ steps.version.outputs.current_version }}
+          PACKAGE_NAME: ${{ steps.version.outputs.package_name }}
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          branch="gh-agent/prepare-release-v$RELEASE_VERSION"
+          title="Prepare release $RELEASE_VERSION"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -c "$branch"
+          git add package.json package-lock.json
+
+          if git diff --cached --quiet; then
+            echo "No version changes were generated."
+            exit 1
+          fi
+
+          git commit -m "chore: prepare release $RELEASE_VERSION"
+          git push --force-with-lease origin "HEAD:$branch"
+
+          cat > /tmp/release-pr-body.md <<EOF
+          ## Background
+
+          This PR prepares the reviewed source state for publishing $PACKAGE_NAME@$RELEASE_VERSION.
+
+          ## Changes
+
+          - Updates package.json from $CURRENT_VERSION to $RELEASE_VERSION.
+          - Updates package-lock.json root package metadata to $RELEASE_VERSION.
+
+          ## Validation
+
+          The prepare workflow ran:
+
+          - npm ci
+          - npm run release:check
+
+          ## Release sequence
+
+          After this PR is reviewed and merged to main, run the Publish package to npm workflow with version $RELEASE_VERSION. The publish workflow verifies that the entered version matches main's committed package.json version before publishing.
+          EOF
+
+          existing_pr="$(gh pr list --head "$branch" --state open --json number --jq '.[0].number // empty')"
+
+          if [ -n "$existing_pr" ]; then
+            gh pr edit "$existing_pr" --title "$title" --body-file /tmp/release-pr-body.md
+            echo "Updated existing release PR #$existing_pr."
+          else
+            gh pr create --base main --head "$branch" --title "$title" --body-file /tmp/release-pr-body.md
+          fi

--- a/docs/release/npm-release.md
+++ b/docs/release/npm-release.md
@@ -40,13 +40,34 @@ Confirm these before the first public npm publication:
 
 ## GitHub npm publication
 
+### Prepare a release PR
+
+For a new npm version, first run the manual `Prepare release PR` workflow from
+the `main` branch. Enter the target SemVer value, such as `0.2.0`.
+
+The workflow does not publish to npm and does not push directly to `main`.
+Instead, it:
+
+- Validates that the requested version is SemVer, differs from the current
+  `package.json#version`, and is not already published on npm.
+- Runs `npm version --no-git-tag-version <version>` so `package.json` and
+  `package-lock.json` are updated together.
+- Runs `npm run release:check`.
+- Pushes a release branch named `gh-agent/prepare-release-v<version>`.
+- Opens or updates a PR titled `Prepare release <version>`.
+
+Review and merge that generated PR before publishing. This keeps the version
+change in the normal GitHub review history.
+
+### Publish the reviewed version
+
 Maintainers can publish from GitHub Actions with the manual `Publish package to
 npm` workflow. Run it from the `main` branch and enter the exact version already
 committed in `package.json`, such as `0.1.0`.
 
 The workflow intentionally does not edit `package.json`, create commits, create
-tags, or publish from release events. Version bumps should happen in a reviewed
-PR first; the manual workflow only validates and publishes the version that is
+tags, or publish from release events. Version bumps happen in a reviewed PR
+first; the manual workflow only validates and publishes the version that is
 already on `main`.
 
 The workflow guards the publish step by:


### PR DESCRIPTION
## Background

#13 added the read-only manual npm publish workflow: it publishes only the version already reviewed and committed on main. During review we split version updates into #14 so the release process can prepare package.json/package-lock changes without letting the publish workflow push directly to main.

## Changes

- Adds a manual `Prepare release PR` workflow with a required version input.
- Requires the workflow to run from `main`.
- Validates the requested version before PR creation: SemVer shape, not the current package version, and not already published on npm.
- Uses `npm version --no-git-tag-version` to update `package.json` and `package-lock.json` together.
- Runs `npm run release:check` before opening/updating the generated release PR.
- Pushes a version-specific `gh-agent/prepare-release-v<version>` branch and opens or updates a reviewable PR.
- Documents the two-step flow: prepare release PR -> review/merge -> publish from reviewed main.

## Validation

- `npm run format:check`
- `npm run release:check`
- `git diff --check`

## Risk / notes

This workflow has `contents: write` and `pull-requests: write` so it can push its generated release branch and open/update the PR. It still does not publish npm and does not push directly to `main`.

Closes #14.