### PR TITLE
fix: include default AGENTS template in build artifacts

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "!dist/test"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.json",
+    "build": "tsc -p tsconfig.json && node ./scripts/copy-assets.mjs",
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "dev": "tsx src/cli.ts",
     "start": "node dist/cli.js",


### PR DESCRIPTION
## Why
`gh-agent init` loads `dist/core/default-agents.md` at runtime. The build pipeline only ran `tsc`, so the markdown asset was missing from `dist/` and npm tarballs, causing an `ENOENT` crash after install/build.

Closes #20.

## What Changed
- Updated `build` script to run `scripts/copy-assets.mjs` after `tsc`.
- This copies markdown assets from `src/**` into matching `dist/**` paths.

## Verification
- `npm run ci:verify`
- Confirmed `npm pack --dry-run` includes `dist/core/default-agents.md`
