### PR TITLE
feat: add agent preset selection for workspace initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,22 @@ gh-agent init
 `gh-agent init` ensures a GitHub Project named `gh-agent` exists on the
 authenticated account (creates it if missing).
 
+In a terminal, it also lets you
+choose which agent CLI to use for the workspace.
+
+For non-interactive setup, you can pass either a built-in preset or a custom
+command directly:
+
+```bash
+gh-agent init --agent codex
+gh-agent init --agent-command 'my-agent "$GH_AGENT_PROMPT"'
+```
+
+When using a custom command:
+
+- `$GH_AGENT_PROMPT` contains the generated session prompt
+- `$GH_AGENT_HOME` points at the workspace root
+
 ### 2) Run the loop
 
 ```bash

--- a/docs/specs/cli.md
+++ b/docs/specs/cli.md
@@ -35,8 +35,15 @@ MVP는 npm 패키지로 배포되는 CLI를 전제로 하며, 사용자는 works
 예상 입력 예시:
 
 - workspace path
-- agent name 또는 identifier
+- `--agent <name>` (`claude-code`, `codex`, `copilot`, `gemini`, `cursor`, `cline`)
 - polling interval 기본값
+- 터미널 환경에서는 agent 번호 목록을 통한 대화형 선택
+
+입력 규칙:
+
+- `--agent`가 있으면 prompt 없이 해당 agent를 사용한다.
+- `--agent`가 없고 TTY가 있으면 번호 기반 대화형 선택을 띄운다.
+- `--agent`가 없고 TTY가 없으면 에러로 종료한다.
 
 ### Side Effects
 

--- a/docs/specs/cli.md
+++ b/docs/specs/cli.md
@@ -36,14 +36,18 @@ MVP는 npm 패키지로 배포되는 CLI를 전제로 하며, 사용자는 works
 
 - workspace path
 - `--agent <name>` (`claude-code`, `codex`, `copilot`, `gemini`, `cursor`, `cline`)
+- `--agent-command <command>`
 - polling interval 기본값
-- 터미널 환경에서는 agent 번호 목록을 통한 대화형 선택
+- 터미널 환경에서는 agent 번호 목록 또는 custom command 입력
 
 입력 규칙:
 
 - `--agent`가 있으면 prompt 없이 해당 agent를 사용한다.
-- `--agent`가 없고 TTY가 있으면 번호 기반 대화형 선택을 띄운다.
-- `--agent`가 없고 TTY가 없으면 에러로 종료한다.
+- `--agent-command`가 있으면 custom command를 사용하며, `--agent`보다 우선한다.
+- `--agent`와 `--agent-command`가 모두 없고 TTY가 있으면 번호 기반 대화형 선택을 띄운다.
+- 번호 목록에는 `Custom command` 항목이 포함된다.
+- `Custom command` 선택 시 `$GH_AGENT_PROMPT` 와 `$GH_AGENT_HOME` 사용 가능 안내를 보여준다.
+- `--agent`와 `--agent-command`가 모두 없고 TTY가 없으면 에러로 종료한다.
 
 ### Side Effects
 

--- a/docs/specs/workspace-layout.md
+++ b/docs/specs/workspace-layout.md
@@ -50,11 +50,12 @@ agent-workspace/
 실행 명령 관련 규칙:
 
 - `agentId`는 식별자다. 실제 실행 커맨드는 `defaultAgentCommand` 와 `heavyAgentCommand` 가 담당한다.
-- `gh-agent init`는 알려진 agent CLI 목록에서 선택하게 하고, 선택 결과를 `defaultAgentCommand`에 저장한다.
+- `gh-agent init`는 알려진 agent CLI 목록 또는 custom command를 선택하게 하고, 선택 결과를 `defaultAgentCommand`에 저장한다.
 - `defaultAgentCommand` 는 항상 문자열이어야 하며 MVP 기본값은 `codex exec --config sandbox_workspace_write.network_access=true --full-auto "$GH_AGENT_PROMPT"` 다.
 - command의 prompt 부분은 시스템이 세션마다 동적으로 생성한 행동 가이드를 주입하는 자리다.
 - command template는 `GH_AGENT_PROMPT` env를 기준으로 맞춘다.
 - 런타임은 모든 agent session에 `GH_AGENT_HOME=<workspace root>` env를 제공한다.
+- custom command 입력 시 사용자가 `$GH_AGENT_PROMPT` 와 `$GH_AGENT_HOME` 를 직접 참조할 수 있다.
 - `heavyAgentCommand` 는 문자열 또는 `null` 이다.
 - heavy command가 `null` 인 경우, heavy 에이전트가 선택되어도 시스템은 기본 command로 폴백할 수 있다.
 

--- a/docs/specs/workspace-layout.md
+++ b/docs/specs/workspace-layout.md
@@ -50,6 +50,7 @@ agent-workspace/
 실행 명령 관련 규칙:
 
 - `agentId`는 식별자다. 실제 실행 커맨드는 `defaultAgentCommand` 와 `heavyAgentCommand` 가 담당한다.
+- `gh-agent init`는 알려진 agent CLI 목록에서 선택하게 하고, 선택 결과를 `defaultAgentCommand`에 저장한다.
 - `defaultAgentCommand` 는 항상 문자열이어야 하며 MVP 기본값은 `codex exec --config sandbox_workspace_write.network_access=true --full-auto "$GH_AGENT_PROMPT"` 다.
 - command의 prompt 부분은 시스템이 세션마다 동적으로 생성한 행동 가이드를 주입하는 자리다.
 - command template는 `GH_AGENT_PROMPT` env를 기준으로 맞춘다.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,6 +14,11 @@ import {
 import { mailboxShowCommand } from './commands/mailbox/show.js';
 import { runCommand } from './commands/run.js';
 import { statusCommand } from './commands/status.js';
+import {
+  type AgentId,
+  formatSupportedAgentIds,
+  parseAgentIdOption,
+} from './core/agents.js';
 import { taskCreateCommand } from './commands/task/create.js';
 import {
   parseTaskExecutionClassOption,
@@ -43,7 +48,12 @@ function createProgram(): Command {
   program
     .command('init')
     .description('Initialize a gh-agent workspace.')
-    .action(initCommand);
+    .option(
+      '--agent <name>',
+      `Agent CLI to configure. One of: ${formatSupportedAgentIds()}`,
+      parseAgentIdOption,
+    )
+    .action(async (options: { agent?: AgentId }) => initCommand(options));
 
   program
     .command('run')

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -53,7 +53,13 @@ function createProgram(): Command {
       `Agent CLI to configure. One of: ${formatSupportedAgentIds()}`,
       parseAgentIdOption,
     )
-    .action(async (options: { agent?: AgentId }) => initCommand(options));
+    .option(
+      '--agent-command <command>',
+      'Custom agent command to store in config.json.',
+    )
+    .action(async (options: { agent?: AgentId; agentCommand?: string }) =>
+      initCommand(options),
+    );
 
   program
     .command('run')

--- a/src/commands/commands.test.ts
+++ b/src/commands/commands.test.ts
@@ -2,6 +2,7 @@ import { mkdir, readFile, writeFile } from 'node:fs/promises';
 
 import { describe, expect, it } from 'vitest';
 
+import { parseAgentIdOption } from '../core/agents.js';
 import { readLockInfo } from '../core/lock.js';
 import {
   GitHubAuthError,
@@ -335,11 +336,17 @@ function createEnsuredProjectStub(
   };
 }
 
+async function initWithCodex(
+  dependencies: Parameters<typeof initCommand>[1] = {},
+) {
+  await initCommand({ agent: 'codex' }, dependencies);
+}
+
 describe('commands', () => {
   it('initCommand creates the workspace files, bootstraps the project, and prints the next steps', async () => {
     const logs = captureConsoleLogs();
 
-    await initCommand({
+    await initWithCodex({
       githubClient: createGitHubClientStub(0, 0),
     });
 
@@ -371,6 +378,7 @@ describe('commands', () => {
     expect(logs).toContain('Ensuring GitHub Project...');
     expect(logs).toContain('Initialized gh-agent workspace');
     expect(logs).toContain('Config: .gh-agent/config.json created');
+    expect(logs).toContain('Agent: OpenAI Codex CLI (codex)');
     expect(logs).toContain('AGENTS.md: created');
     expect(logs).toContain('GitHub Project: created gh-agent');
     expect(logs).toContain(
@@ -382,10 +390,95 @@ describe('commands', () => {
     expect(agentsFile).toContain('## Core Role');
   });
 
+  it('initCommand applies the selected agent command from interactive selection', async () => {
+    await initCommand(
+      {},
+      {
+        githubClient: createGitHubClientStub(0, 0),
+        isInteractive: true,
+        async promptForAgent() {
+          return 'cursor';
+        },
+      },
+    );
+
+    const paths = getWorkspacePaths(getWorkspaceRoot());
+    const config = JSON.parse(
+      await readFile(paths.configFile, 'utf8'),
+    ) as Record<string, unknown>;
+
+    expect(config.defaultAgentCommand).toBe(
+      'cursor-agent -p "$GH_AGENT_PROMPT" --force',
+    );
+  });
+
+  it('initCommand requires --agent in non-interactive mode', async () => {
+    await expect(
+      initCommand(
+        {},
+        {
+          githubClient: createGitHubClientStub(0, 0),
+          isInteractive: false,
+        },
+      ),
+    ).rejects.toMatchObject({
+      message:
+        'Non-interactive mode requires --agent. Re-run with gh-agent init --agent <name>.',
+      exitCode: 2,
+    });
+  });
+
+  it('initCommand overwrites an existing default agent command with the selected agent', async () => {
+    const paths = getWorkspacePaths(getWorkspaceRoot());
+    await mkdir(paths.stateDir, { recursive: true });
+    await writeFile(
+      paths.configFile,
+      JSON.stringify({
+        defaultAgentCommand: 'codex exec "$GH_AGENT_PROMPT"',
+      }),
+      'utf8',
+    );
+
+    await initCommand(
+      { agent: 'gemini' },
+      {
+        githubClient: createGitHubClientStub(0, 0),
+      },
+    );
+
+    const config = JSON.parse(
+      await readFile(paths.configFile, 'utf8'),
+    ) as Record<string, unknown>;
+
+    expect(config.defaultAgentCommand).toBe(
+      'gemini --prompt "$GH_AGENT_PROMPT" --yolo',
+    );
+  });
+
+  it('initCommand surfaces agent prompt cancellation clearly', async () => {
+    await expect(
+      initCommand(
+        {},
+        {
+          githubClient: createGitHubClientStub(0, 0),
+          isInteractive: true,
+          async promptForAgent() {
+            const error = new Error('prompt aborted');
+            error.name = 'ExitPromptError';
+            throw error;
+          },
+        },
+      ),
+    ).rejects.toMatchObject({
+      message: 'Agent selection was cancelled.',
+      exitCode: 1,
+    });
+  });
+
   it('statusCommand reads the current state and reports an unlocked workspace', async () => {
     const logs = captureConsoleLogs();
 
-    await initCommand({
+    await initWithCodex({
       githubClient: createGitHubClientStub(0, 0),
     });
     await statusCommand(
@@ -416,7 +509,7 @@ describe('commands', () => {
   it('statusCommand resolves the nearest workspace root from nested directories', async () => {
     const logs = captureConsoleLogs();
 
-    await initCommand({
+    await initWithCodex({
       githubClient: createGitHubClientStub(0, 0),
     });
 
@@ -443,7 +536,7 @@ describe('commands', () => {
     };
     let didCaptureExecuteInput = false;
 
-    await initCommand({
+    await initWithCodex({
       githubClient: createGitHubClientStub(0, 0),
     });
     await runCommand(
@@ -501,7 +594,7 @@ describe('commands', () => {
       env: {},
     };
 
-    await initCommand({
+    await initWithCodex({
       githubClient: createGitHubClientStub(0, 0),
     });
 
@@ -530,7 +623,7 @@ describe('commands', () => {
   it('runCommand respects cooldown and still releases the lock', async () => {
     const logs = captureConsoleLogs();
 
-    await initCommand({
+    await initWithCodex({
       githubClient: createGitHubClientStub(0, 0),
     });
     const paths = getWorkspacePaths(getWorkspaceRoot());
@@ -572,7 +665,7 @@ describe('commands', () => {
   it('runCommand records a session failure and still returns to sleeping mode', async () => {
     const logs = captureConsoleLogs();
 
-    await initCommand({
+    await initWithCodex({
       githubClient: createGitHubClientStub(0, 0),
     });
     await runCommand(
@@ -608,7 +701,7 @@ describe('commands', () => {
   it('runCommand injects recent updated task cards into prompt context', async () => {
     const prompts: string[] = [];
 
-    await initCommand({
+    await initWithCodex({
       githubClient: createGitHubClientStub(0, 0),
     });
 
@@ -662,7 +755,7 @@ describe('commands', () => {
   it('mailboxListCommand prints JSON with one object per line by default', async () => {
     const logs = captureConsoleLogs();
 
-    await initCommand({
+    await initWithCodex({
       githubClient: createGitHubClientStub(0, 0),
     });
     await mailboxListCommand(
@@ -681,7 +774,7 @@ describe('commands', () => {
   it('mailboxListCommand respects the limit option', async () => {
     const logs = captureConsoleLogs();
 
-    await initCommand({
+    await initWithCodex({
       githubClient: createGitHubClientStub(0, 0),
     });
     await mailboxListCommand(
@@ -701,7 +794,7 @@ describe('commands', () => {
   it('mailboxListCommand prints an empty JSON array when no unread notifications exist', async () => {
     const logs = captureConsoleLogs();
 
-    await initCommand({
+    await initWithCodex({
       githubClient: createGitHubClientStub(0, 0),
     });
     await mailboxListCommand(
@@ -722,7 +815,7 @@ describe('commands', () => {
   it('mailboxPromoteCommand promotes multiple threads and prints JSON results', async () => {
     const logs = captureConsoleLogs();
 
-    await initCommand({
+    await initWithCodex({
       githubClient: createGitHubClientStub(0, 0),
     });
     await mailboxPromoteCommand(
@@ -742,7 +835,7 @@ describe('commands', () => {
   it('mailboxWaitCommand and mailboxReadyCommand force their status aliases', async () => {
     const logs = captureConsoleLogs();
 
-    await initCommand({
+    await initWithCodex({
       githubClient: createGitHubClientStub(0, 0),
     });
     await mailboxWaitCommand(
@@ -772,7 +865,7 @@ describe('commands', () => {
     const logs = captureConsoleLogs();
     const markedAsRead: string[] = [];
 
-    await initCommand({
+    await initWithCodex({
       githubClient: createGitHubClientStub(0, 0),
     });
 
@@ -818,7 +911,7 @@ describe('commands', () => {
     const logs = captureConsoleLogs();
     const markedAsRead: string[] = [];
 
-    await initCommand({
+    await initWithCodex({
       githubClient: createGitHubClientStub(0, 0),
     });
     await mailboxIgnoreCommand(
@@ -845,7 +938,7 @@ describe('commands', () => {
     const logs = captureConsoleLogs();
     const markedAsRead: string[] = [];
 
-    await initCommand({
+    await initWithCodex({
       githubClient: createGitHubClientStub(0, 0),
     });
 
@@ -881,7 +974,7 @@ describe('commands', () => {
   it('mailboxShowCommand prints thread details and related cards as JSON', async () => {
     const logs = captureConsoleLogs();
 
-    await initCommand({
+    await initWithCodex({
       githubClient: createGitHubClientStub(0, 0),
     });
     await mailboxShowCommand(
@@ -916,7 +1009,7 @@ describe('commands', () => {
   it('mailboxShowCommand returns an empty relatedCards array when no exact match exists', async () => {
     const logs = captureConsoleLogs();
 
-    await initCommand({
+    await initWithCodex({
       githubClient: createGitHubClientStub(0, 0),
     });
     await mailboxShowCommand(
@@ -943,7 +1036,7 @@ describe('commands', () => {
   it('taskListCommand prints compact JSON rows', async () => {
     const logs = captureConsoleLogs();
 
-    await initCommand({
+    await initWithCodex({
       githubClient: createGitHubClientStub(0, 0),
     });
     await taskListCommand({}, { githubClient: createGitHubClientStub(0, 0) });
@@ -979,7 +1072,7 @@ describe('commands', () => {
   it('taskListCommand honors status, priority, type, and execution class filters', async () => {
     const logs = captureConsoleLogs();
 
-    await initCommand({
+    await initWithCodex({
       githubClient: createGitHubClientStub(0, 0),
     });
     await taskListCommand(
@@ -1011,7 +1104,7 @@ describe('commands', () => {
   it('taskShowCommand prints full card JSON', async () => {
     const logs = captureConsoleLogs();
 
-    await initCommand({
+    await initWithCodex({
       githubClient: createGitHubClientStub(0, 0),
     });
     await taskShowCommand(
@@ -1040,7 +1133,7 @@ describe('commands', () => {
   it('taskCreateCommand requires title and status and prints the created card JSON', async () => {
     const logs = captureConsoleLogs();
 
-    await initCommand({
+    await initWithCodex({
       githubClient: createGitHubClientStub(0, 0),
     });
     await taskCreateCommand(
@@ -1075,7 +1168,7 @@ describe('commands', () => {
   it('taskUpdateCommand patches only supplied fields', async () => {
     const logs = captureConsoleLogs();
 
-    await initCommand({
+    await initWithCodex({
       githubClient: createGitHubClientStub(0, 0),
     });
     await taskUpdateCommand(
@@ -1112,7 +1205,7 @@ describe('commands', () => {
   it('task status commands update multiple ids and fail after mixed results', async () => {
     const logs = captureConsoleLogs();
 
-    await initCommand({
+    await initWithCodex({
       githubClient: createGitHubClientStub(0, 0),
     });
 
@@ -1152,7 +1245,7 @@ describe('commands', () => {
   it('task status aliases force the requested statuses', async () => {
     const logs = captureConsoleLogs();
 
-    await initCommand({
+    await initWithCodex({
       githubClient: createGitHubClientStub(0, 0),
     });
     await taskReadyCommand(
@@ -1261,10 +1354,16 @@ describe('commands', () => {
     );
   });
 
+  it('parseInitAgentOption rejects unsupported agents', () => {
+    expect(() => parseAgentIdOption('unknown')).toThrow(
+      'The --agent option must be one of: copilot, claude-code, codex, gemini, cursor, cline.',
+    );
+  });
+
   it('initCommand reuses an existing gh-agent project without duplicating it', async () => {
     const logs = captureConsoleLogs();
 
-    await initCommand({
+    await initWithCodex({
       githubClient: {
         ...createGitHubClientStub(0, 0),
         async ensureProject() {
@@ -1281,7 +1380,7 @@ describe('commands', () => {
     let authChecks = 0;
     let loginCalled = false;
 
-    await initCommand({
+    await initWithCodex({
       githubClient: {
         ...createGitHubClientStub(0, 0),
         async login() {
@@ -1315,7 +1414,7 @@ describe('commands', () => {
 
   it('initCommand maps GitHub authentication failures to exit code 3 when login does not authenticate the workspace', async () => {
     await expect(
-      initCommand({
+      initWithCodex({
         githubClient: {
           ...createGitHubClientStub(0, 0),
           async getAuthStatus(paths) {
@@ -1338,7 +1437,7 @@ describe('commands', () => {
     let refreshCalled = false;
     let ensureCalls = 0;
 
-    await initCommand({
+    await initWithCodex({
       githubClient: {
         ...createGitHubClientStub(0, 0),
         async refreshProjectScopes() {
@@ -1368,7 +1467,7 @@ describe('commands', () => {
 
   it('initCommand includes the failing bootstrap stage in the error message', async () => {
     await expect(
-      initCommand({
+      initWithCodex({
         githubClient: {
           ...createGitHubClientStub(0, 0),
           async ensureProject() {
@@ -1388,7 +1487,7 @@ describe('commands', () => {
 
   it('initCommand fails with exit code 2 when the existing Status field schema conflicts', async () => {
     await expect(
-      initCommand({
+      initWithCodex({
         githubClient: {
           ...createGitHubClientStub(0, 0),
           async ensureProject() {
@@ -1403,7 +1502,7 @@ describe('commands', () => {
   });
 
   it('runCommand maps GitHub authentication failures to exit code 3', async () => {
-    await initCommand({
+    await initWithCodex({
       githubClient: createGitHubClientStub(0, 0),
     });
 
@@ -1499,7 +1598,7 @@ describe('commands', () => {
   });
 
   it('mailboxListCommand maps GitHub authentication failures to exit code 3', async () => {
-    await initCommand({
+    await initWithCodex({
       githubClient: createGitHubClientStub(0, 0),
     });
 
@@ -1526,7 +1625,7 @@ describe('commands', () => {
   });
 
   it('mailboxPromoteCommand maps GitHub authentication failures to exit code 3', async () => {
-    await initCommand({
+    await initWithCodex({
       githubClient: createGitHubClientStub(0, 0),
     });
 
@@ -1566,7 +1665,7 @@ describe('commands', () => {
   });
 
   it('mailboxIgnoreCommand maps GitHub authentication failures to exit code 3', async () => {
-    await initCommand({
+    await initWithCodex({
       githubClient: createGitHubClientStub(0, 0),
     });
 
@@ -1606,7 +1705,7 @@ describe('commands', () => {
   });
 
   it('mailboxShowCommand maps GitHub authentication failures to exit code 3', async () => {
-    await initCommand({
+    await initWithCodex({
       githubClient: createGitHubClientStub(0, 0),
     });
 
@@ -1646,7 +1745,7 @@ describe('commands', () => {
   });
 
   it('task commands map GitHub authentication failures to exit code 3', async () => {
-    await initCommand({
+    await initWithCodex({
       githubClient: createGitHubClientStub(0, 0),
     });
 

--- a/src/commands/commands.test.ts
+++ b/src/commands/commands.test.ts
@@ -18,7 +18,7 @@ import {
   captureConsoleLogs,
   setupWorkspaceTest,
 } from '../test/test-helpers.js';
-import { initCommand } from './init.js';
+import { initCommand, promptForCustomCommand } from './init.js';
 import { mailboxIgnoreCommand } from './mailbox/ignore.js';
 import { mailboxListCommand } from './mailbox/list.js';
 import {
@@ -396,8 +396,11 @@ describe('commands', () => {
       {
         githubClient: createGitHubClientStub(0, 0),
         isInteractive: true,
-        async promptForAgent() {
-          return 'cursor';
+        async promptForSelection() {
+          return {
+            label: 'Cursor CLI (cursor)',
+            command: 'cursor-agent -p "$GH_AGENT_PROMPT" --force',
+          };
         },
       },
     );
@@ -423,9 +426,77 @@ describe('commands', () => {
       ),
     ).rejects.toMatchObject({
       message:
-        'Non-interactive mode requires --agent. Re-run with gh-agent init --agent <name>.',
+        'Non-interactive mode requires --agent or --agent-command. Re-run with gh-agent init --agent <name> or --agent-command "<command>".',
       exitCode: 2,
     });
+  });
+
+  it('initCommand accepts a custom agent command in non-interactive mode', async () => {
+    const logs = captureConsoleLogs();
+
+    await initCommand(
+      {
+        agentCommand: 'my-agent "$GH_AGENT_PROMPT" --cwd "$GH_AGENT_HOME"',
+      },
+      {
+        githubClient: createGitHubClientStub(0, 0),
+        isInteractive: false,
+      },
+    );
+
+    const paths = getWorkspacePaths(getWorkspaceRoot());
+    const config = JSON.parse(
+      await readFile(paths.configFile, 'utf8'),
+    ) as Record<string, unknown>;
+
+    expect(config.defaultAgentCommand).toBe(
+      'my-agent "$GH_AGENT_PROMPT" --cwd "$GH_AGENT_HOME"',
+    );
+    expect(
+      logs.some((line) => line.startsWith('Agent: Custom command (my-agent ')),
+    ).toBe(true);
+  });
+
+  it('initCommand applies a custom command chosen from interactive selection', async () => {
+    await initCommand(
+      {},
+      {
+        githubClient: createGitHubClientStub(0, 0),
+        isInteractive: true,
+        async promptForSelection() {
+          return {
+            label: 'Custom command (custom-agent "$GH_AGENT_PROMPT")',
+            command: 'custom-agent "$GH_AGENT_PROMPT"',
+          };
+        },
+      },
+    );
+
+    const paths = getWorkspacePaths(getWorkspaceRoot());
+    const config = JSON.parse(
+      await readFile(paths.configFile, 'utf8'),
+    ) as Record<string, unknown>;
+
+    expect(config.defaultAgentCommand).toBe('custom-agent "$GH_AGENT_PROMPT"');
+  });
+
+  it('initCommand prefers --agent-command over --agent when both are provided', async () => {
+    await initCommand(
+      {
+        agent: 'codex',
+        agentCommand: 'custom-agent "$GH_AGENT_PROMPT"',
+      },
+      {
+        githubClient: createGitHubClientStub(0, 0),
+      },
+    );
+
+    const paths = getWorkspacePaths(getWorkspaceRoot());
+    const config = JSON.parse(
+      await readFile(paths.configFile, 'utf8'),
+    ) as Record<string, unknown>;
+
+    expect(config.defaultAgentCommand).toBe('custom-agent "$GH_AGENT_PROMPT"');
   });
 
   it('initCommand overwrites an existing default agent command with the selected agent', async () => {
@@ -462,7 +533,7 @@ describe('commands', () => {
         {
           githubClient: createGitHubClientStub(0, 0),
           isInteractive: true,
-          async promptForAgent() {
+          async promptForSelection() {
             const error = new Error('prompt aborted');
             error.name = 'ExitPromptError';
             throw error;
@@ -473,6 +544,34 @@ describe('commands', () => {
       message: 'Agent selection was cancelled.',
       exitCode: 1,
     });
+  });
+
+  it('promptForCustomCommand prints env var help and reprompts on empty input', async () => {
+    const logs = captureConsoleLogs();
+    const asked: string[] = [];
+    const answers = ['', 'custom-agent "$GH_AGENT_PROMPT" "$GH_AGENT_HOME"'];
+    let closed = false;
+
+    const selection = await promptForCustomCommand({
+      async question(query) {
+        asked.push(query);
+        return answers.shift() ?? '';
+      },
+      close() {
+        closed = true;
+      },
+    });
+
+    expect(selection.command).toBe(
+      'custom-agent "$GH_AGENT_PROMPT" "$GH_AGENT_HOME"',
+    );
+    expect(selection.label.startsWith('Custom command (custom-agent ')).toBe(
+      true,
+    );
+    expect(asked).toEqual(['Command: ', 'Command: ']);
+    expect(logs).toContain('Enter a one-line custom agent command.');
+    expect(logs).toContain('Please enter a non-empty command.');
+    expect(closed).toBe(false);
   });
 
   it('statusCommand reads the current state and reports an unlocked workspace', async () => {

--- a/src/commands/commands.test.ts
+++ b/src/commands/commands.test.ts
@@ -499,7 +499,7 @@ describe('commands', () => {
     expect(config.defaultAgentCommand).toBe('custom-agent "$GH_AGENT_PROMPT"');
   });
 
-  it('initCommand overwrites an existing default agent command with the selected agent', async () => {
+  it('initCommand updates an existing agent command when an agent option is provided', async () => {
     const paths = getWorkspacePaths(getWorkspaceRoot());
     await mkdir(paths.stateDir, { recursive: true });
     await writeFile(
@@ -523,6 +523,73 @@ describe('commands', () => {
 
     expect(config.defaultAgentCommand).toBe(
       'gemini --prompt "$GH_AGENT_PROMPT" --yolo',
+    );
+  });
+
+  it('initCommand updates an existing agent command when a custom command option is provided', async () => {
+    const paths = getWorkspacePaths(getWorkspaceRoot());
+    await mkdir(paths.stateDir, { recursive: true });
+    await writeFile(
+      paths.configFile,
+      JSON.stringify({
+        defaultAgentCommand: 'codex exec "$GH_AGENT_PROMPT"',
+      }),
+      'utf8',
+    );
+
+    await initCommand(
+      {
+        agentCommand: 'custom-agent "$GH_AGENT_PROMPT" "$GH_AGENT_HOME"',
+      },
+      {
+        githubClient: createGitHubClientStub(0, 0),
+      },
+    );
+
+    const config = JSON.parse(
+      await readFile(paths.configFile, 'utf8'),
+    ) as Record<string, unknown>;
+
+    expect(config.defaultAgentCommand).toBe(
+      'custom-agent "$GH_AGENT_PROMPT" "$GH_AGENT_HOME"',
+    );
+  });
+
+  it('initCommand skips interactive selection when an agent command is already configured', async () => {
+    const paths = getWorkspacePaths(getWorkspaceRoot());
+    await mkdir(paths.stateDir, { recursive: true });
+    await writeFile(
+      paths.configFile,
+      JSON.stringify({
+        defaultAgentCommand: 'existing-agent "$GH_AGENT_PROMPT"',
+      }),
+      'utf8',
+    );
+
+    let promptCalled = false;
+
+    await initCommand(
+      {},
+      {
+        githubClient: createGitHubClientStub(0, 0),
+        isInteractive: true,
+        async promptForSelection() {
+          promptCalled = true;
+          return {
+            label: 'Gemini CLI (gemini)',
+            command: 'gemini --prompt "$GH_AGENT_PROMPT" --yolo',
+          };
+        },
+      },
+    );
+
+    const config = JSON.parse(
+      await readFile(paths.configFile, 'utf8'),
+    ) as Record<string, unknown>;
+
+    expect(promptCalled).toBe(false);
+    expect(config.defaultAgentCommand).toBe(
+      'existing-agent "$GH_AGENT_PROMPT"',
     );
   });
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,3 +1,6 @@
+import { createInterface } from 'node:readline/promises';
+import process from 'node:process';
+
 import {
   ensureAgentsGuide,
   saveConfig,
@@ -9,12 +12,93 @@ import {
   pathExists,
 } from '../core/workspace.js';
 import {
+  AGENT_DEFINITIONS,
+  type AgentId,
+  getAgentDefinition,
+} from '../core/agents.js';
+import {
   createGitHubSignalClient,
   GitHubAuthError,
   GitHubBootstrapError,
   GitHubConfigError,
 } from '../core/github.js';
 import type { GitHubSignalClient } from '../core/types.js';
+
+export interface InitCommandOptions {
+  agent?: AgentId;
+}
+
+interface InitCommandDependencies {
+  githubClient?: GitHubSignalClient;
+  isInteractive?: boolean;
+  promptForAgent?: () => Promise<AgentId>;
+}
+
+function isInitCommandDependencies(
+  value: InitCommandOptions | InitCommandDependencies,
+): value is InitCommandDependencies {
+  return (
+    'githubClient' in value ||
+    'isInteractive' in value ||
+    'promptForAgent' in value
+  );
+}
+
+function isInteractiveTerminal(): boolean {
+  return process.stdin.isTTY === true && process.stdout.isTTY === true;
+}
+
+function mapAgentPromptError(error: unknown): never {
+  if (error instanceof Error && error.name === 'ExitPromptError') {
+    throw Object.assign(new Error('Agent selection was cancelled.'), {
+      exitCode: 1,
+    });
+  }
+
+  throw error;
+}
+
+export async function selectAgentPrompt(): Promise<AgentId> {
+  const readline = createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  try {
+    console.log('Select the agent CLI for this workspace:');
+    for (const [index, agent] of AGENT_DEFINITIONS.entries()) {
+      console.log(`  ${index + 1}. ${agent.label} (${agent.id})`);
+    }
+
+    while (true) {
+      const answer = (await readline.question('Enter a number: ')).trim();
+
+      if (answer.length === 0) {
+        console.log('Please enter a number from the list.');
+        continue;
+      }
+
+      const selectedIndex = Number.parseInt(answer, 10);
+
+      if (
+        Number.isFinite(selectedIndex) &&
+        String(selectedIndex) === answer &&
+        selectedIndex >= 1 &&
+        selectedIndex <= AGENT_DEFINITIONS.length
+      ) {
+        return AGENT_DEFINITIONS[selectedIndex - 1].id;
+      }
+
+      console.log(
+        `Please enter a number between 1 and ${AGENT_DEFINITIONS.length}.`,
+      );
+    }
+  } catch (error) {
+    mapAgentPromptError(error);
+  } finally {
+    readline.close();
+  }
+}
 
 function isMissingProjectScopeError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
@@ -25,20 +109,51 @@ function isMissingProjectScopeError(error: unknown): boolean {
 }
 
 export async function initCommand(
-  dependencies: {
-    githubClient?: GitHubSignalClient;
-  } = {},
+  optionsOrDependencies: InitCommandOptions | InitCommandDependencies = {},
+  dependenciesArg: InitCommandDependencies = {},
 ): Promise<void> {
+  const options = isInitCommandDependencies(optionsOrDependencies)
+    ? {}
+    : optionsOrDependencies;
+  const dependencies = isInitCommandDependencies(optionsOrDependencies)
+    ? optionsOrDependencies
+    : dependenciesArg;
   const paths = getWorkspacePaths();
   const githubClient = dependencies.githubClient ?? createGitHubSignalClient();
+  const isInteractive = dependencies.isInteractive ?? isInteractiveTerminal();
+  let selectedAgentId = options.agent ?? null;
+
+  if (selectedAgentId === null && isInteractive) {
+    try {
+      selectedAgentId = await (
+        dependencies.promptForAgent ?? selectAgentPrompt
+      )();
+    } catch (error) {
+      mapAgentPromptError(error);
+    }
+  }
+
+  if (selectedAgentId === null) {
+    throw Object.assign(
+      new Error(
+        'Non-interactive mode requires --agent. Re-run with gh-agent init --agent <name>.',
+      ),
+      { exitCode: 2 },
+    );
+  }
+  const agentDefinition = getAgentDefinition(selectedAgentId);
 
   await ensureWorkspaceStructure(paths);
 
   const hadConfig = await pathExists(paths.configFile);
   const config = await ensureConfig(paths);
+  const configWithSelectedAgent = {
+    ...config,
+    defaultAgentCommand: agentDefinition.defaultAgentCommand,
+  };
 
   const hadState = await pathExists(paths.stateFile);
-  await ensureSessionState(paths, config.agentId);
+  await ensureSessionState(paths, configWithSelectedAgent.agentId);
   const agentsGuide = await ensureAgentsGuide(paths);
 
   try {
@@ -76,7 +191,7 @@ export async function initCommand(
     }
 
     const updatedConfig = {
-      ...config,
+      ...configWithSelectedAgent,
       projectId: project.projectId,
       projectTitle: project.projectTitle,
       projectUrl: project.projectUrl,
@@ -92,6 +207,7 @@ export async function initCommand(
     console.log(
       `Config: ${hadConfig ? 'existing .gh-agent/config.json updated' : '.gh-agent/config.json created'}`,
     );
+    console.log(`Agent: ${agentDefinition.label} (${agentDefinition.id})`);
     console.log(
       `Session state: ${hadState ? 'existing .gh-agent/session_state.json kept' : '.gh-agent/session_state.json created'}`,
     );

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -26,12 +26,23 @@ import type { GitHubSignalClient } from '../core/types.js';
 
 export interface InitCommandOptions {
   agent?: AgentId;
+  agentCommand?: string;
+}
+
+export interface InitCommandSelection {
+  label: string;
+  command: string;
+}
+
+export interface AgentPromptReadline {
+  question(query: string): Promise<string>;
+  close(): void;
 }
 
 interface InitCommandDependencies {
   githubClient?: GitHubSignalClient;
   isInteractive?: boolean;
-  promptForAgent?: () => Promise<AgentId>;
+  promptForSelection?: () => Promise<InitCommandSelection>;
 }
 
 function isInitCommandDependencies(
@@ -40,7 +51,7 @@ function isInitCommandDependencies(
   return (
     'githubClient' in value ||
     'isInteractive' in value ||
-    'promptForAgent' in value
+    'promptForSelection' in value
   );
 }
 
@@ -49,7 +60,10 @@ function isInteractiveTerminal(): boolean {
 }
 
 function mapAgentPromptError(error: unknown): never {
-  if (error instanceof Error && error.name === 'ExitPromptError') {
+  if (
+    error instanceof Error &&
+    (error.name === 'ExitPromptError' || error.name === 'AbortError')
+  ) {
     throw Object.assign(new Error('Agent selection was cancelled.'), {
       exitCode: 1,
     });
@@ -58,7 +72,49 @@ function mapAgentPromptError(error: unknown): never {
   throw error;
 }
 
-export async function selectAgentPrompt(): Promise<AgentId> {
+function createPresetSelection(agentId: AgentId): InitCommandSelection {
+  const agentDefinition = getAgentDefinition(agentId);
+
+  return {
+    label: `${agentDefinition.label} (${agentDefinition.id})`,
+    command: agentDefinition.defaultAgentCommand,
+  };
+}
+
+function createCustomCommandSelection(command: string): InitCommandSelection {
+  return {
+    label: `Custom command (${formatCommandPreview(command)})`,
+    command,
+  };
+}
+
+function formatCommandPreview(command: string): string {
+  const normalized = command.trim().replace(/\s+/g, ' ');
+
+  if (normalized.length <= 48) {
+    return normalized;
+  }
+
+  return `${normalized.slice(0, 45)}...`;
+}
+
+export async function promptForCustomCommand(
+  readline: AgentPromptReadline,
+): Promise<InitCommandSelection> {
+  console.log('Enter a one-line custom agent command.');
+
+  while (true) {
+    const command = (await readline.question('Command: ')).trim();
+
+    if (command.length > 0) {
+      return createCustomCommandSelection(command);
+    }
+
+    console.log('Please enter a non-empty command.');
+  }
+}
+
+export async function selectAgentPrompt(): Promise<InitCommandSelection> {
   const readline = createInterface({
     input: process.stdin,
     output: process.stdout,
@@ -69,6 +125,8 @@ export async function selectAgentPrompt(): Promise<AgentId> {
     for (const [index, agent] of AGENT_DEFINITIONS.entries()) {
       console.log(`  ${index + 1}. ${agent.label} (${agent.id})`);
     }
+    const customCommandIndex = AGENT_DEFINITIONS.length + 1;
+    console.log(`  ${customCommandIndex}. Custom command`);
 
     while (true) {
       const answer = (await readline.question('Enter a number: ')).trim();
@@ -86,12 +144,18 @@ export async function selectAgentPrompt(): Promise<AgentId> {
         selectedIndex >= 1 &&
         selectedIndex <= AGENT_DEFINITIONS.length
       ) {
-        return AGENT_DEFINITIONS[selectedIndex - 1].id;
+        return createPresetSelection(AGENT_DEFINITIONS[selectedIndex - 1].id);
       }
 
-      console.log(
-        `Please enter a number between 1 and ${AGENT_DEFINITIONS.length}.`,
-      );
+      if (
+        Number.isFinite(selectedIndex) &&
+        String(selectedIndex) === answer &&
+        selectedIndex === customCommandIndex
+      ) {
+        return await promptForCustomCommand(readline);
+      }
+
+      console.log(`Please enter a number between 1 and ${customCommandIndex}.`);
     }
   } catch (error) {
     mapAgentPromptError(error);
@@ -121,27 +185,33 @@ export async function initCommand(
   const paths = getWorkspacePaths();
   const githubClient = dependencies.githubClient ?? createGitHubSignalClient();
   const isInteractive = dependencies.isInteractive ?? isInteractiveTerminal();
-  let selectedAgentId = options.agent ?? null;
+  const customAgentCommand =
+    typeof options.agentCommand === 'string' ? options.agentCommand.trim() : '';
+  let selection: InitCommandSelection | null =
+    customAgentCommand.length > 0
+      ? createCustomCommandSelection(customAgentCommand)
+      : options.agent !== undefined
+        ? createPresetSelection(options.agent)
+        : null;
 
-  if (selectedAgentId === null && isInteractive) {
+  if (selection === null && isInteractive) {
     try {
-      selectedAgentId = await (
-        dependencies.promptForAgent ?? selectAgentPrompt
+      selection = await (
+        dependencies.promptForSelection ?? selectAgentPrompt
       )();
     } catch (error) {
       mapAgentPromptError(error);
     }
   }
 
-  if (selectedAgentId === null) {
+  if (selection === null) {
     throw Object.assign(
       new Error(
-        'Non-interactive mode requires --agent. Re-run with gh-agent init --agent <name>.',
+        'Non-interactive mode requires --agent or --agent-command. Re-run with gh-agent init --agent <name> or --agent-command "<command>".',
       ),
       { exitCode: 2 },
     );
   }
-  const agentDefinition = getAgentDefinition(selectedAgentId);
 
   await ensureWorkspaceStructure(paths);
 
@@ -149,7 +219,7 @@ export async function initCommand(
   const config = await ensureConfig(paths);
   const configWithSelectedAgent = {
     ...config,
-    defaultAgentCommand: agentDefinition.defaultAgentCommand,
+    defaultAgentCommand: selection.command,
   };
 
   const hadState = await pathExists(paths.stateFile);
@@ -207,7 +277,7 @@ export async function initCommand(
     console.log(
       `Config: ${hadConfig ? 'existing .gh-agent/config.json updated' : '.gh-agent/config.json created'}`,
     );
-    console.log(`Agent: ${agentDefinition.label} (${agentDefinition.id})`);
+    console.log(`Agent: ${selection.label}`);
     console.log(
       `Session state: ${hadState ? 'existing .gh-agent/session_state.json kept' : '.gh-agent/session_state.json created'}`,
     );

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -184,17 +184,25 @@ export async function initCommand(
     : dependenciesArg;
   const paths = getWorkspacePaths();
   const githubClient = dependencies.githubClient ?? createGitHubSignalClient();
+  await ensureWorkspaceStructure(paths);
+  const hadConfig = await pathExists(paths.configFile);
+  const config = await ensureConfig(paths);
   const isInteractive = dependencies.isInteractive ?? isInteractiveTerminal();
   const customAgentCommand =
     typeof options.agentCommand === 'string' ? options.agentCommand.trim() : '';
-  let selection: InitCommandSelection | null =
+  const requestedSelection =
     customAgentCommand.length > 0
       ? createCustomCommandSelection(customAgentCommand)
       : options.agent !== undefined
         ? createPresetSelection(options.agent)
         : null;
+  let selection: InitCommandSelection;
 
-  if (selection === null && isInteractive) {
+  if (requestedSelection !== null) {
+    selection = requestedSelection;
+  } else if (hadConfig) {
+    selection = createCustomCommandSelection(config.defaultAgentCommand);
+  } else if (isInteractive) {
     try {
       selection = await (
         dependencies.promptForSelection ?? selectAgentPrompt
@@ -202,9 +210,7 @@ export async function initCommand(
     } catch (error) {
       mapAgentPromptError(error);
     }
-  }
-
-  if (selection === null) {
+  } else {
     throw Object.assign(
       new Error(
         'Non-interactive mode requires --agent or --agent-command. Re-run with gh-agent init --agent <name> or --agent-command "<command>".',
@@ -213,10 +219,6 @@ export async function initCommand(
     );
   }
 
-  await ensureWorkspaceStructure(paths);
-
-  const hadConfig = await pathExists(paths.configFile);
-  const config = await ensureConfig(paths);
   const configWithSelectedAgent = {
     ...config,
     defaultAgentCommand: selection.command,

--- a/src/core/agents.ts
+++ b/src/core/agents.ts
@@ -1,0 +1,93 @@
+export type AgentId =
+  | 'claude-code'
+  | 'codex'
+  | 'copilot'
+  | 'gemini'
+  | 'cursor'
+  | 'cline';
+
+export interface AgentDefinition {
+  id: AgentId;
+  label: string;
+  description: string;
+  defaultAgentCommand: string;
+}
+
+export const AGENT_DEFINITIONS = [
+  {
+    id: 'copilot',
+    label: 'GitHub Copilot CLI',
+    description: 'Run Copilot CLI in autopilot mode without extra prompts.',
+    defaultAgentCommand:
+      'copilot --prompt "$GH_AGENT_PROMPT" --allow-all --autopilot --no-ask-user',
+  },
+  {
+    id: 'claude-code',
+    label: 'Claude Code',
+    description: 'Run Claude Code with Read/Edit/Bash tools enabled.',
+    defaultAgentCommand:
+      'claude -p "$GH_AGENT_PROMPT" --allowedTools "Read,Edit,Bash"',
+  },
+  {
+    id: 'codex',
+    label: 'OpenAI Codex CLI',
+    description:
+      'Run Codex in full-auto mode with workspace-write networking enabled.',
+    defaultAgentCommand:
+      'codex exec --config sandbox_workspace_write.network_access=true --full-auto "$GH_AGENT_PROMPT"',
+  },
+  {
+    id: 'gemini',
+    label: 'Gemini CLI',
+    description: 'Run Gemini CLI with yolo mode enabled.',
+    defaultAgentCommand: 'gemini --prompt "$GH_AGENT_PROMPT" --yolo',
+  },
+  {
+    id: 'cursor',
+    label: 'Cursor CLI',
+    description: 'Run Cursor Agent with force mode enabled.',
+    defaultAgentCommand: 'cursor-agent -p "$GH_AGENT_PROMPT" --force',
+  },
+  {
+    id: 'cline',
+    label: 'Cline CLI',
+    description: 'Run Cline in yes-to-all mode.',
+    defaultAgentCommand: 'cline -y "$GH_AGENT_PROMPT"',
+  },
+] as const satisfies readonly AgentDefinition[];
+
+const AGENT_DEFINITION_MAP = new Map(
+  AGENT_DEFINITIONS.map((agent: AgentDefinition) => [agent.id, agent]),
+);
+
+export const DEFAULT_AGENT_ID: AgentId = 'codex';
+
+export function getSupportedAgentIds(): AgentId[] {
+  return Array.from(AGENT_DEFINITION_MAP.keys());
+}
+
+export function formatSupportedAgentIds(): string {
+  return getSupportedAgentIds().join(', ');
+}
+
+export function isAgentId(value: string): value is AgentId {
+  return AGENT_DEFINITION_MAP.has(value as AgentId);
+}
+
+export function parseAgentIdOption(value: string): AgentId {
+  if (!isAgentId(value)) {
+    throw new Error(
+      `The --agent option must be one of: ${formatSupportedAgentIds()}.`,
+    );
+  }
+
+  return value;
+}
+
+export function getAgentDefinition(agentId: AgentId): AgentDefinition {
+  return AGENT_DEFINITION_MAP.get(agentId) as AgentDefinition;
+}
+
+export function getDefaultAgentDefinition(): AgentDefinition {
+  return getAgentDefinition(DEFAULT_AGENT_ID);
+}

--- a/src/core/workspace.ts
+++ b/src/core/workspace.ts
@@ -18,6 +18,7 @@ import type {
   ProjectStatusOptionIds,
   SessionState,
 } from './types.js';
+import { getDefaultAgentDefinition } from './agents.js';
 
 export interface WorkspacePaths {
   root: string;
@@ -71,8 +72,7 @@ function createEmptyProjectExecutionClassOptionIds(): ProjectExecutionClassOptio
 
 export const DEFAULT_CONFIG: Config = {
   agentId: 'gh-agent',
-  defaultAgentCommand:
-    'codex exec --config sandbox_workspace_write.network_access=true --full-auto "$GH_AGENT_PROMPT"',
+  defaultAgentCommand: getDefaultAgentDefinition().defaultAgentCommand,
   heavyAgentCommand: null,
   pollIntervalMs: 30_000,
   debounceMs: 60_000,


### PR DESCRIPTION
Closes #22 

## Background

`gh-agent init` was effectively biased toward a single default agent command. This PR makes init easier to use across multiple well-known agent CLIs while keeping automation explicit.

## Changes

- Code: add a shared agent registry and support `gh-agent init --agent <name>`
- Code: add interactive numeric agent selection when `--agent` is omitted in a TTY
- Code: write the selected agent command into `.gh-agent/config.json` and show the applied agent in init output
- Code: fail clearly in non-interactive mode when `--agent` is missing
- Docs: update CLI/workspace specs for the new init flow
- Tests: cover agent parsing, interactive selection, non-interactive failure, cancellation, and command overwrite behavior

## Tests

- [ ] Docs-only changes: `npm run format:check`
- [x] Code, test, or config behavior changes: `npm run ci:verify`
- [ ] Not run

## Risks

Interactive selection depends on standard terminal input/output behavior. Non-TTY environments must use `--agent`.

## Follow-ups

None.
