### PR TITLE
fix: fall back when release workflow cannot open PRs

### DIFF
--- a/.github/workflows/prepare-release-pr.yml
+++ b/.github/workflows/prepare-release-pr.yml
@@ -86,6 +86,7 @@ jobs:
         run: |
           branch="gh-agent/prepare-release-v$RELEASE_VERSION"
           title="Prepare release $RELEASE_VERSION"
+          compare_url="https://github.com/$GITHUB_REPOSITORY/compare/main...$branch?expand=1"
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -128,5 +129,27 @@ jobs:
             gh pr edit "$existing_pr" --title "$title" --body-file /tmp/release-pr-body.md
             echo "Updated existing release PR #$existing_pr."
           else
-            gh pr create --base main --head "$branch" --title "$title" --body-file /tmp/release-pr-body.md
+            set +e
+            create_output="$(gh pr create --base main --head "$branch" --title "$title" --body-file /tmp/release-pr-body.md 2>&1)"
+            create_status=$?
+            set -e
+
+            if [ "$create_status" -eq 0 ]; then
+              printf '%s\n' "$create_output"
+            elif printf '%s' "$create_output" | grep -Fq 'GitHub Actions is not permitted to create or approve pull requests'; then
+              echo "GitHub Actions could not create the release PR automatically because repository settings currently disallow PR creation from GITHUB_TOKEN."
+              echo "The release branch was pushed successfully. Create the PR manually:"
+              echo "$compare_url"
+              {
+                echo "## Manual PR follow-up required"
+                echo
+                echo "GitHub Actions pushed \`$branch\` successfully, but the repository currently disallows pull request creation from \`GITHUB_TOKEN\`."
+                echo
+                echo "Create the release PR manually:"
+                echo "$compare_url"
+              } >> "$GITHUB_STEP_SUMMARY"
+            else
+              printf '%s\n' "$create_output"
+              exit "$create_status"
+            fi
           fi


### PR DESCRIPTION
## Background

The `Prepare release PR` workflow currently succeeds through version validation, version bumping, and `npm run ci:verify`, then fails only at `gh pr create` because this repository does not currently allow GitHub Actions to create pull requests with `GITHUB_TOKEN`.

Issue #35 shows the failure mode clearly: the workflow already pushed `gh-agent/prepare-release-v0.1.1`, but the run still ended red instead of leaving a usable manual follow-up path.

## Changes

- Keep the existing automatic `gh pr edit` path when a release PR already exists.
- Keep the existing automatic `gh pr create` path when repository settings allow it.
- When PR creation is blocked specifically by the GitHub Actions restriction, treat the branch push as success and write a manual compare URL to the logs and step summary instead of failing the workflow.
- Preserve hard failure behavior for unrelated `gh pr create` errors.

## Validation

- `npm ci`
- `npm run ci:verify`

## Risks

- This does not bypass the repository setting; it makes the workflow degrade cleanly until the owner enables automatic PR creation for Actions.
