### PR TITLE
test: add command usage examples

### DIFF
--- a/src/commands/mailbox.test.ts
+++ b/src/commands/mailbox.test.ts
@@ -1,0 +1,258 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  createCommandGitHubClientStub,
+  createCommandTestWorkspace,
+  parseLastJsonLog,
+} from '../test/command-fixtures.js';
+import type {
+  MailboxIgnoreResult,
+  MailboxNotification,
+  MailboxPromotionResult,
+  MailboxShowResult,
+} from '../core/types.js';
+import {
+  captureConsoleLogs,
+  setupWorkspaceTest,
+} from '../test/test-helpers.js';
+import { mailboxIgnoreCommand } from './mailbox/ignore.js';
+import { mailboxListCommand } from './mailbox/list.js';
+import { mailboxReadyCommand, mailboxWaitCommand } from './mailbox/promote.js';
+import { mailboxShowCommand } from './mailbox/show.js';
+
+const { getWorkspaceRoot } = setupWorkspaceTest();
+
+describe('mailbox commands', () => {
+  describe('usage examples', () => {
+    it('lists unread notification rows with thread ids for follow-up commands', async () => {
+      const logs = captureConsoleLogs();
+      await createCommandTestWorkspace(getWorkspaceRoot());
+
+      await mailboxListCommand(
+        { limit: 2 },
+        {
+          githubClient: createCommandGitHubClientStub(),
+        },
+      );
+
+      expect(parseLastJsonLog<MailboxNotification[]>(logs)).toEqual([
+        {
+          id: 'thread_1',
+          repositoryFullName: 'acme/widgets',
+          title: 'Review mailbox triage',
+          reason: 'review_requested',
+          type: 'PullRequest',
+          updatedAt: '2026-04-20T10:00:00.000Z',
+        },
+        {
+          id: 'thread_2',
+          repositoryFullName: 'acme/docs',
+          title: 'Triage docs cleanup',
+          reason: 'mention',
+          type: 'Issue',
+          updatedAt: '2026-04-21T10:00:00.000Z',
+        },
+      ]);
+    });
+
+    it('shows a mailbox thread with its source URL and related project cards', async () => {
+      const logs = captureConsoleLogs();
+      await createCommandTestWorkspace(getWorkspaceRoot());
+
+      await mailboxShowCommand(
+        'thread_1',
+        {},
+        {
+          githubClient: createCommandGitHubClientStub(),
+        },
+      );
+
+      expect(parseLastJsonLog<MailboxShowResult>(logs)).toEqual({
+        threadId: 'thread_1',
+        repositoryFullName: 'acme/widgets',
+        title: 'Review mailbox triage',
+        reason: 'review_requested',
+        type: 'PullRequest',
+        unread: true,
+        updatedAt: '2026-04-20T10:00:00.000Z',
+        sourceUrl: 'https://github.com/acme/widgets/pull/7',
+        relatedCards: [
+          {
+            id: 'item_related_1',
+            projectId: 'proj_123',
+            title: 'Review mailbox triage',
+            sourceLink: 'https://github.com/acme/widgets/pull/7',
+            status: 'ready',
+          },
+        ],
+      });
+    });
+
+    it('marks selected threads ready or waiting and returns one result per thread', async () => {
+      const logs = captureConsoleLogs();
+      await createCommandTestWorkspace(getWorkspaceRoot());
+
+      await mailboxReadyCommand(
+        ['thread_1'],
+        {},
+        {
+          githubClient: createCommandGitHubClientStub(),
+        },
+      );
+      await mailboxWaitCommand(
+        ['thread_2'],
+        {},
+        {
+          githubClient: createCommandGitHubClientStub(),
+        },
+      );
+
+      const outputs = logs
+        .filter((line) => line.startsWith('['))
+        .map((line) => JSON.parse(line) as MailboxPromotionResult[]);
+
+      expect(outputs).toEqual([
+        [
+          {
+            threadId: 'thread_1',
+            status: 'ready',
+            ok: true,
+            card: {
+              id: 'item_thread_1',
+              projectId: 'proj_123',
+              title: 'Review mailbox triage',
+              sourceLink: 'https://github.com/acme/widgets/pull/7',
+              status: 'ready',
+            },
+          },
+        ],
+        [
+          {
+            threadId: 'thread_2',
+            status: 'waiting',
+            ok: true,
+            card: {
+              id: 'item_thread_2',
+              projectId: 'proj_123',
+              title: 'Triage docs cleanup',
+              sourceLink: 'https://github.com/acme/docs/issues/2',
+              status: 'waiting',
+            },
+          },
+        ],
+      ]);
+    });
+
+    it('ignores selected threads by marking them read without creating cards', async () => {
+      const logs = captureConsoleLogs();
+      const markedAsRead: string[] = [];
+      await createCommandTestWorkspace(getWorkspaceRoot());
+
+      await mailboxIgnoreCommand(
+        ['thread_1', 'thread_2'],
+        {},
+        {
+          githubClient: createCommandGitHubClientStub({
+            async markMailboxThreadAsRead(_paths, threadId) {
+              markedAsRead.push(threadId);
+            },
+          }),
+        },
+      );
+
+      expect(markedAsRead).toEqual(['thread_1', 'thread_2']);
+      expect(parseLastJsonLog<MailboxIgnoreResult[]>(logs)).toEqual([
+        {
+          threadId: 'thread_1',
+          ok: true,
+          read: true,
+        },
+        {
+          threadId: 'thread_2',
+          ok: true,
+          read: true,
+        },
+      ]);
+    });
+  });
+
+  describe('behavior checks', () => {
+    it('continues promoting later threads and fails after mixed promotion results', async () => {
+      const logs = captureConsoleLogs();
+      await createCommandTestWorkspace(getWorkspaceRoot());
+
+      await expect(
+        mailboxReadyCommand(
+          ['thread_1', 'thread_2'],
+          {},
+          {
+            githubClient: createCommandGitHubClientStub({
+              async promoteMailboxThread(_paths, config, target, status) {
+                if (target.threadId === 'thread_2') {
+                  throw new Error('promotion failed for thread_2');
+                }
+
+                return {
+                  id: `item_${target.threadId}`,
+                  projectId: config.projectId as string,
+                  title: target.title,
+                  sourceLink: target.sourceUrl,
+                  status,
+                };
+              },
+            }),
+          },
+        ),
+      ).rejects.toMatchObject({
+        message: 'One or more mailbox thread promotions failed.',
+        exitCode: 1,
+      });
+
+      expect(parseLastJsonLog<MailboxPromotionResult[]>(logs)).toEqual([
+        {
+          threadId: 'thread_1',
+          status: 'ready',
+          ok: true,
+          card: {
+            id: 'item_thread_1',
+            projectId: 'proj_123',
+            title: 'Review mailbox triage',
+            sourceLink: 'https://github.com/acme/widgets/pull/7',
+            status: 'ready',
+          },
+        },
+        {
+          threadId: 'thread_2',
+          status: 'ready',
+          ok: false,
+          error: 'promotion failed for thread_2',
+          errorCategory: 'runtime',
+        },
+      ]);
+    });
+
+    it('maps unauthenticated mailbox access to exit code 3', async () => {
+      await createCommandTestWorkspace(getWorkspaceRoot());
+
+      await expect(
+        mailboxListCommand(
+          {},
+          {
+            githubClient: createCommandGitHubClientStub({
+              async getAuthStatus(paths) {
+                return {
+                  kind: 'unauthenticated',
+                  detail: 'not logged in',
+                  ghConfigDir: paths.ghConfigDir,
+                };
+              },
+            }),
+          },
+        ),
+      ).rejects.toMatchObject({
+        message: 'GitHub authentication error: not logged in',
+        exitCode: 3,
+      });
+    });
+  });
+});

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  createCommandGitHubClientStub,
+  createCommandTestWorkspace,
+} from '../test/command-fixtures.js';
+import {
+  captureConsoleLogs,
+  setupWorkspaceTest,
+} from '../test/test-helpers.js';
+import { statusCommand } from './status.js';
+
+const { getWorkspaceRoot } = setupWorkspaceTest();
+
+describe('status command', () => {
+  describe('usage examples', () => {
+    it('shows the current workspace, project, lock, auth, and signal counts', async () => {
+      const logs = captureConsoleLogs();
+      await createCommandTestWorkspace(getWorkspaceRoot());
+
+      await statusCommand(
+        {},
+        {
+          githubClient: createCommandGitHubClientStub(),
+        },
+      );
+
+      expect(logs).toContain(`Workspace: ${getWorkspaceRoot()}`);
+      expect(logs).toContain(
+        `Config: ${getWorkspaceRoot()}/.gh-agent/config.json`,
+      );
+      expect(logs).toContain('Agent: gh-agent');
+      expect(logs).toContain('Project: gh-agent');
+      expect(logs).toContain(
+        'Project URL: https://github.com/users/test/projects/1',
+      );
+      expect(logs).toContain('Mode: sleeping');
+      expect(logs).toContain('Lock: unlocked');
+      expect(logs).toContain('Unread notifications: 2');
+      expect(logs).toContain('Actionable cards: 1');
+      expect(logs).toContain('Actionable rule: Status in {Ready, Doing}');
+      expect(logs).toContain('GitHub auth: authenticated');
+      expect(logs).toContain('GitHub auth detail: stubbed auth status');
+    });
+  });
+
+  describe('behavior checks', () => {
+    it('omits signal counts when GitHub auth is unavailable', async () => {
+      const logs = captureConsoleLogs();
+      await createCommandTestWorkspace(getWorkspaceRoot());
+
+      await statusCommand(
+        {},
+        {
+          githubClient: createCommandGitHubClientStub({
+            async getAuthStatus(paths) {
+              return {
+                kind: 'unauthenticated',
+                detail: 'not logged in',
+                ghConfigDir: paths.ghConfigDir,
+              };
+            },
+          }),
+        },
+      );
+
+      expect(logs).toContain('Unread notifications: -');
+      expect(logs).toContain('Actionable cards: -');
+      expect(logs).toContain('GitHub auth: unauthenticated');
+      expect(logs).toContain('GitHub auth detail: not logged in');
+    });
+  });
+});

--- a/src/commands/task.test.ts
+++ b/src/commands/task.test.ts
@@ -1,0 +1,279 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  createCommandGitHubClientStub,
+  createCommandTestWorkspace,
+  createTaskCardFixture,
+  parseLastJsonLog,
+} from '../test/command-fixtures.js';
+import type {
+  TaskCard,
+  TaskListItem,
+  TaskStatusUpdateResult,
+} from '../core/types.js';
+import {
+  captureConsoleLogs,
+  setupWorkspaceTest,
+} from '../test/test-helpers.js';
+import { taskCreateCommand } from './task/create.js';
+import { taskListCommand } from './task/list.js';
+import { taskShowCommand } from './task/show.js';
+import {
+  taskDoingCommand,
+  taskDoneCommand,
+  taskReadyCommand,
+  taskWaitCommand,
+} from './task/status.js';
+import { taskUpdateCommand } from './task/update.js';
+
+const { getWorkspaceRoot } = setupWorkspaceTest();
+
+describe('task commands', () => {
+  describe('usage examples', () => {
+    it('lists task rows with the fields agents need for triage decisions', async () => {
+      const logs = captureConsoleLogs();
+      await createCommandTestWorkspace(getWorkspaceRoot());
+
+      await taskListCommand(
+        {
+          statuses: ['ready', 'waiting'],
+        },
+        {
+          githubClient: createCommandGitHubClientStub(),
+        },
+      );
+
+      expect(parseLastJsonLog<TaskListItem[]>(logs)).toEqual([
+        {
+          id: 'item_1',
+          title: 'Fix mailbox sync',
+          updatedAt: '2026-04-20T10:00:00.000Z',
+          status: 'ready',
+          priority: 'P1',
+          type: 'execution',
+          executionClass: 'light',
+          sourceLink: 'https://github.com/acme/widgets/issues/7',
+          nextAction: 'Open a narrow implementation PR',
+          shortNote: 'Ready for implementation',
+        },
+        {
+          id: 'item_2',
+          title: 'Reply to docs question',
+          updatedAt: '2026-04-21T10:00:00.000Z',
+          status: 'waiting',
+          priority: 'P3',
+          type: 'interaction',
+          executionClass: 'heavy',
+          sourceLink: 'https://github.com/acme/docs/issues/2',
+          nextAction: 'Wait for owner clarification',
+          shortNote: 'Owner question needs a response',
+        },
+      ]);
+    });
+
+    it('shows one task card with project metadata and durable next action text', async () => {
+      const logs = captureConsoleLogs();
+      await createCommandTestWorkspace(getWorkspaceRoot());
+
+      await taskShowCommand(
+        'item_1',
+        {},
+        {
+          githubClient: createCommandGitHubClientStub(),
+        },
+      );
+
+      expect(parseLastJsonLog<TaskCard>(logs)).toEqual({
+        id: 'item_1',
+        projectId: 'proj_123',
+        title: 'Fix mailbox sync',
+        updatedAt: '2026-04-20T10:00:00.000Z',
+        status: 'ready',
+        priority: 'P1',
+        type: 'execution',
+        executionClass: 'light',
+        sourceLink: 'https://github.com/acme/widgets/issues/7',
+        nextAction: 'Open a narrow implementation PR',
+        shortNote: 'Ready for implementation',
+      });
+    });
+
+    it('creates a task from explicit title, status, source link, and review notes', async () => {
+      const logs = captureConsoleLogs();
+      await createCommandTestWorkspace(getWorkspaceRoot());
+
+      await taskCreateCommand(
+        {
+          title: 'Document mailbox usage',
+          status: 'ready',
+          priority: 'P2',
+          type: 'execution',
+          executionClass: 'light',
+          sourceLink: 'https://github.com/acme/widgets/issues/9',
+          nextAction: 'Add usage examples for mailbox commands',
+          shortNote: 'Created from command usage test',
+        },
+        {
+          githubClient: createCommandGitHubClientStub(),
+        },
+      );
+
+      expect(parseLastJsonLog<TaskCard>(logs)).toEqual({
+        id: 'item_created',
+        projectId: 'proj_123',
+        title: 'Document mailbox usage',
+        updatedAt: null,
+        status: 'ready',
+        priority: 'P2',
+        type: 'execution',
+        executionClass: 'light',
+        sourceLink: 'https://github.com/acme/widgets/issues/9',
+        nextAction: 'Add usage examples for mailbox commands',
+        shortNote: 'Created from command usage test',
+      });
+    });
+
+    it('updates only the supplied task fields and keeps the rest unchanged', async () => {
+      const logs = captureConsoleLogs();
+      await createCommandTestWorkspace(getWorkspaceRoot());
+
+      await taskUpdateCommand(
+        'item_1',
+        {
+          status: 'doing',
+          nextAction: 'Push a focused PR for review',
+        },
+        {
+          githubClient: createCommandGitHubClientStub(),
+        },
+      );
+
+      expect(parseLastJsonLog<TaskCard>(logs)).toEqual({
+        id: 'item_1',
+        projectId: 'proj_123',
+        title: 'Fix mailbox sync',
+        updatedAt: '2026-04-20T10:00:00.000Z',
+        status: 'doing',
+        priority: 'P1',
+        type: 'execution',
+        executionClass: 'light',
+        sourceLink: 'https://github.com/acme/widgets/issues/7',
+        nextAction: 'Push a focused PR for review',
+        shortNote: 'Ready for implementation',
+      });
+    });
+
+    it('moves selected tasks through the ready, doing, waiting, and done aliases', async () => {
+      const logs = captureConsoleLogs();
+      await createCommandTestWorkspace(getWorkspaceRoot());
+
+      await taskReadyCommand(
+        ['item_1'],
+        {},
+        {
+          githubClient: createCommandGitHubClientStub(),
+        },
+      );
+      await taskDoingCommand(
+        ['item_1'],
+        {},
+        {
+          githubClient: createCommandGitHubClientStub(),
+        },
+      );
+      await taskWaitCommand(
+        ['item_1'],
+        {},
+        {
+          githubClient: createCommandGitHubClientStub(),
+        },
+      );
+      await taskDoneCommand(
+        ['item_1'],
+        {},
+        {
+          githubClient: createCommandGitHubClientStub(),
+        },
+      );
+
+      const statuses = logs
+        .filter((line) => line.startsWith('['))
+        .flatMap((line) =>
+          (JSON.parse(line) as TaskStatusUpdateResult[]).map(
+            (result) => result.status,
+          ),
+        );
+
+      expect(statuses).toEqual(['ready', 'doing', 'waiting', 'done']);
+    });
+  });
+
+  describe('behavior checks', () => {
+    it('continues updating later tasks and fails after mixed status results', async () => {
+      const logs = captureConsoleLogs();
+      await createCommandTestWorkspace(getWorkspaceRoot());
+
+      await expect(
+        taskDoneCommand(
+          ['item_1', 'item_2'],
+          {},
+          {
+            githubClient: createCommandGitHubClientStub({
+              async setTaskCardStatus(_paths, _config, taskId, status) {
+                if (taskId === 'item_2') {
+                  throw new Error('status update failed for item_2');
+                }
+
+                return {
+                  ...createTaskCardFixture(taskId),
+                  status,
+                };
+              },
+            }),
+          },
+        ),
+      ).rejects.toMatchObject({
+        message: 'One or more task status updates failed.',
+        exitCode: 1,
+      });
+
+      expect(parseLastJsonLog<TaskStatusUpdateResult[]>(logs)).toEqual([
+        {
+          taskId: 'item_1',
+          status: 'done',
+          ok: true,
+          task: {
+            id: 'item_1',
+            title: 'Fix mailbox sync',
+            updatedAt: '2026-04-20T10:00:00.000Z',
+            status: 'done',
+            priority: 'P1',
+            type: 'execution',
+            executionClass: 'light',
+            sourceLink: 'https://github.com/acme/widgets/issues/7',
+            nextAction: 'Open a narrow implementation PR',
+            shortNote: 'Ready for implementation',
+          },
+        },
+        {
+          taskId: 'item_2',
+          status: 'done',
+          ok: false,
+          error: 'status update failed for item_2',
+          errorCategory: 'runtime',
+        },
+      ]);
+    });
+
+    it('rejects task creation without the required status option', async () => {
+      await expect(
+        taskCreateCommand({
+          title: 'Missing status example',
+        }),
+      ).rejects.toMatchObject({
+        message: 'The --status option is required.',
+        exitCode: 1,
+      });
+    });
+  });
+});

--- a/src/test/command-fixtures.ts
+++ b/src/test/command-fixtures.ts
@@ -1,0 +1,310 @@
+import { writeFile } from 'node:fs/promises';
+
+import { expect } from 'vitest';
+
+import type {
+  Config,
+  GitHubSignalClient,
+  MailboxNotification,
+  MailboxThreadDetail,
+  TaskCard,
+  TaskListFilters,
+  TaskListItem,
+} from '../core/types.js';
+import {
+  createInitialSessionState,
+  DEFAULT_CONFIG,
+  ensureWorkspaceStructure,
+  getWorkspacePaths,
+  saveConfig,
+  saveSessionState,
+} from '../core/workspace.js';
+
+export const PROJECT_ID = 'proj_123';
+
+export function createCommandTestConfig(): Config {
+  return {
+    ...DEFAULT_CONFIG,
+    agentId: 'gh-agent',
+    projectId: PROJECT_ID,
+    projectTitle: 'gh-agent',
+    projectUrl: 'https://github.com/users/test/projects/1',
+  };
+}
+
+export async function createCommandTestWorkspace(root: string): Promise<void> {
+  const paths = getWorkspacePaths(root);
+  const config = createCommandTestConfig();
+
+  await ensureWorkspaceStructure(paths);
+  await saveConfig(paths, config);
+  await saveSessionState(paths, {
+    ...createInitialSessionState(config.agentId),
+    lastNotificationPollAt: '2026-04-21T10:00:00.000Z',
+  });
+  await writeFile(paths.agentsFile, '# AGENTS.md\n', 'utf8');
+}
+
+export function createMailboxNotificationFixture(
+  id: string,
+): MailboxNotification {
+  return {
+    id,
+    repositoryFullName: id === 'thread_2' ? 'acme/docs' : 'acme/widgets',
+    title: id === 'thread_2' ? 'Triage docs cleanup' : 'Review mailbox triage',
+    reason: id === 'thread_2' ? 'mention' : 'review_requested',
+    type: id === 'thread_2' ? 'Issue' : 'PullRequest',
+    updatedAt:
+      id === 'thread_2'
+        ? '2026-04-21T10:00:00.000Z'
+        : '2026-04-20T10:00:00.000Z',
+  };
+}
+
+export function createMailboxThreadFixture(
+  threadId: string,
+): MailboxThreadDetail {
+  const notification = createMailboxNotificationFixture(threadId);
+  const sourceUrl =
+    threadId === 'thread_2'
+      ? 'https://github.com/acme/docs/issues/2'
+      : 'https://github.com/acme/widgets/pull/7';
+
+  return {
+    id: threadId,
+    repositoryFullName: notification.repositoryFullName,
+    reason: notification.reason,
+    isUnread: threadId !== 'thread_read',
+    updatedAt: notification.updatedAt,
+    subject: {
+      title: notification.title,
+      type: notification.type,
+      url: sourceUrl,
+    },
+  };
+}
+
+export function createTaskCardFixture(taskId: string): TaskCard {
+  return {
+    id: taskId,
+    projectId: PROJECT_ID,
+    title: taskId === 'item_2' ? 'Reply to docs question' : 'Fix mailbox sync',
+    updatedAt:
+      taskId === 'item_2'
+        ? '2026-04-21T10:00:00.000Z'
+        : '2026-04-20T10:00:00.000Z',
+    status: taskId === 'item_2' ? 'waiting' : 'ready',
+    priority: taskId === 'item_2' ? 'P3' : 'P1',
+    type: taskId === 'item_2' ? 'interaction' : 'execution',
+    executionClass: taskId === 'item_2' ? 'heavy' : 'light',
+    sourceLink:
+      taskId === 'item_2'
+        ? 'https://github.com/acme/docs/issues/2'
+        : 'https://github.com/acme/widgets/issues/7',
+    nextAction:
+      taskId === 'item_2'
+        ? 'Wait for owner clarification'
+        : 'Open a narrow implementation PR',
+    shortNote:
+      taskId === 'item_2'
+        ? 'Owner question needs a response'
+        : 'Ready for implementation',
+  };
+}
+
+function toTaskListItem(task: TaskCard): TaskListItem {
+  const { projectId, ...listItem } = task;
+  void projectId;
+
+  return listItem;
+}
+
+export function createCommandGitHubClientStub(
+  overrides: Partial<GitHubSignalClient> = {},
+): GitHubSignalClient {
+  return {
+    async login() {
+      return;
+    },
+    async refreshProjectScopes() {
+      return;
+    },
+    async ensureProject() {
+      return {
+        wasCreated: false,
+        projectId: PROJECT_ID,
+        projectTitle: 'gh-agent',
+        projectUrl: 'https://github.com/users/test/projects/1',
+        projectFieldIds: {
+          status: 'field_status',
+          priority: 'field_priority',
+          type: 'field_type',
+          executionClass: 'field_execution_class',
+          sourceLink: 'field_source_link',
+          nextAction: 'field_next_action',
+          shortNote: 'field_short_note',
+        },
+        projectStatusOptionIds: {
+          ready: 'status_ready',
+          doing: 'status_doing',
+          waiting: 'status_waiting',
+          done: 'status_done',
+        },
+        projectExecutionClassOptionIds: {
+          light: 'execution_class_light',
+          heavy: 'execution_class_heavy',
+        },
+      };
+    },
+    async getSignalSummary(_paths, config) {
+      expect(config.projectId).toBe(PROJECT_ID);
+      return {
+        unreadCount: 2,
+        actionableCount: 1,
+      };
+    },
+    async listMailboxNotifications(_paths, options) {
+      return ['thread_1', 'thread_2']
+        .map(createMailboxNotificationFixture)
+        .slice(0, options?.limit ?? 2);
+    },
+    async getMailboxThreadDetail(_paths, threadId) {
+      if (threadId === 'missing_thread') {
+        throw new Error('Mailbox thread "missing_thread" was not found.');
+      }
+
+      return createMailboxThreadFixture(threadId);
+    },
+    async promoteMailboxThread(_paths, config, target, status) {
+      expect(config.projectId).toBe(PROJECT_ID);
+
+      return {
+        id: `item_${target.threadId}`,
+        projectId: PROJECT_ID,
+        title: target.title,
+        sourceLink: target.sourceUrl,
+        status,
+      };
+    },
+    async markMailboxThreadAsRead() {
+      return;
+    },
+    async listRelatedMailboxCards(_paths, config, sourceUrl) {
+      expect(config.projectId).toBe(PROJECT_ID);
+
+      if (!sourceUrl.endsWith('/pull/7')) {
+        return [];
+      }
+
+      return [
+        {
+          id: 'item_related_1',
+          projectId: PROJECT_ID,
+          title: 'Review mailbox triage',
+          sourceLink: sourceUrl,
+          status: 'ready',
+        },
+      ];
+    },
+    async listTaskCards(_paths, config, filters: TaskListFilters = {}) {
+      expect(config.projectId).toBe(PROJECT_ID);
+
+      return ['item_1', 'item_2']
+        .map(createTaskCardFixture)
+        .filter((task) => {
+          if (
+            filters.statuses !== undefined &&
+            !filters.statuses.includes(task.status)
+          ) {
+            return false;
+          }
+
+          if (
+            filters.priority !== undefined &&
+            task.priority !== filters.priority
+          ) {
+            return false;
+          }
+
+          if (filters.type !== undefined && task.type !== filters.type) {
+            return false;
+          }
+
+          if (
+            filters.executionClass !== undefined &&
+            task.executionClass !== filters.executionClass
+          ) {
+            return false;
+          }
+
+          return true;
+        })
+        .map(toTaskListItem);
+    },
+    async getTaskCard(_paths, config, taskId) {
+      expect(config.projectId).toBe(PROJECT_ID);
+
+      if (taskId === 'missing_item') {
+        throw new Error(
+          'GitHub Project item "missing_item" was not found in the configured project.',
+        );
+      }
+
+      return createTaskCardFixture(taskId);
+    },
+    async createTaskCard(_paths, config, input) {
+      expect(config.projectId).toBe(PROJECT_ID);
+
+      return {
+        id: 'item_created',
+        projectId: PROJECT_ID,
+        title: input.title,
+        updatedAt: null,
+        status: input.status,
+        priority: input.priority ?? null,
+        type: input.type ?? null,
+        executionClass: input.executionClass ?? null,
+        sourceLink: input.sourceLink ?? null,
+        nextAction: input.nextAction ?? null,
+        shortNote: input.shortNote ?? null,
+      };
+    },
+    async updateTaskCard(_paths, config, taskId, input) {
+      expect(config.projectId).toBe(PROJECT_ID);
+
+      return {
+        ...createTaskCardFixture(taskId),
+        ...Object.fromEntries(
+          Object.entries(input).filter(([, value]) => value !== undefined),
+        ),
+      };
+    },
+    async setTaskCardStatus(_paths, config, taskId, status) {
+      expect(config.projectId).toBe(PROJECT_ID);
+
+      return {
+        ...createTaskCardFixture(taskId),
+        status,
+      };
+    },
+    async getAuthStatus(paths) {
+      return {
+        kind: 'authenticated',
+        detail: 'stubbed auth status',
+        ghConfigDir: paths.ghConfigDir,
+      };
+    },
+    async getGitIdentity() {
+      return {
+        login: 'test-user',
+        name: 'Test User',
+        email: '123+test-user@users.noreply.github.com',
+      };
+    },
+    ...overrides,
+  };
+}
+
+export function parseLastJsonLog<T>(logs: string[]): T {
+  return JSON.parse(logs.at(-1) ?? 'null') as T;
+}


### PR DESCRIPTION
## Why

Issue #40 asks for test code that can be read as command usage documentation for agent-facing commands. The owner also clarified that usage-expression tests should be separated from failure/edge-case verification and grouped by large command units.

## What changed

- Added `status`, `mailbox`, and `task` command-unit test files.
- Grouped each file into `usage examples` and narrower `behavior checks` where applicable.
- Added shared command test fixtures for workspace setup, stubbed GitHub state, and JSON log parsing.
- Kept the change test-only; no command runtime behavior changed.

Closes #40

## Verification

- `npm run test -- src/commands/status.test.ts src/commands/mailbox.test.ts src/commands/task.test.ts`
- `npm run ci:verify`

## Risks / follow-up

- The existing monolithic `commands.test.ts` still carries broad command behavior coverage. This PR adds readable command-unit examples first rather than moving all old cases at once, to keep review scope narrow. Future cleanup can migrate redundant cases after this structure is accepted.