### PR TITLE
fix: retry transient GitHub API failures

### DIFF
--- a/src/core/github.test.ts
+++ b/src/core/github.test.ts
@@ -420,6 +420,35 @@ describe('GitHub mailbox mutations', () => {
     }
   });
 
+  it('retries observed REST authentication failures during notification polling', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    octokitPaginateMock
+      .mockRejectedValueOnce(
+        createOctokitError(
+          'Requires authentication - https://docs.github.com/rest',
+        ),
+      )
+      .mockResolvedValueOnce([]);
+
+    try {
+      const client = createGitHubSignalClient();
+      const notifications = await client.listMailboxNotifications({
+        ghConfigDir: '/tmp/gh-config-retry-observed-auth',
+      });
+
+      expect(notifications).toEqual([]);
+      expect(octokitPaginateMock).toHaveBeenCalledTimes(2);
+      expect(octokitConstructorMock).toHaveBeenCalledTimes(2);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'GitHub API list unread notifications failed on attempt 1',
+        ),
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
   it('does not retry permanent validation failures', async () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     octokitRequestMock.mockRejectedValueOnce(

--- a/src/core/github.test.ts
+++ b/src/core/github.test.ts
@@ -147,6 +147,13 @@ function createProjectValueNode(items: unknown[]): {
   };
 }
 
+function createOctokitError(
+  message: string,
+  details: { status?: number; code?: string } = {},
+): Error & { status?: number; code?: string } {
+  return Object.assign(new Error(message), details);
+}
+
 beforeEach(() => {
   execFileMock.mockReset();
   spawnMock.mockReset();
@@ -340,6 +347,124 @@ describe('parseMailboxNotificationsPayload', () => {
 });
 
 describe('GitHub mailbox mutations', () => {
+  it('retries transient notification list failures before returning mailbox notifications', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    octokitPaginateMock
+      .mockRejectedValueOnce(
+        createOctokitError('socket hang up', { code: 'ECONNRESET' }),
+      )
+      .mockResolvedValueOnce([
+        {
+          id: 'thread_retry',
+          reason: 'assign',
+          updated_at: '2026-04-20T10:00:00Z',
+          repository: { full_name: 'acme/widgets' },
+          subject: {
+            title: 'Retry GitHub polling',
+            type: 'Issue',
+          },
+        },
+      ]);
+
+    try {
+      const client = createGitHubSignalClient();
+      const notifications = await client.listMailboxNotifications({
+        ghConfigDir: '/tmp/gh-config-retry-network',
+      });
+
+      expect(notifications).toEqual([
+        {
+          id: 'thread_retry',
+          repositoryFullName: 'acme/widgets',
+          title: 'Retry GitHub polling',
+          reason: 'assign',
+          type: 'Issue',
+          updatedAt: '2026-04-20T10:00:00.000Z',
+        },
+      ]);
+      expect(octokitPaginateMock).toHaveBeenCalledTimes(2);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'GitHub API list unread notifications failed on attempt 1',
+        ),
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('retries auth-looking API failures after an authenticated Octokit client exists', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    octokitRequestMock
+      .mockRejectedValueOnce(
+        createOctokitError('Bad credentials', { status: 401 }),
+      )
+      .mockResolvedValueOnce({ data: {} });
+
+    try {
+      const client = createGitHubSignalClient();
+      await client.markMailboxThreadAsRead(
+        { ghConfigDir: '/tmp/gh-config-retry-auth' },
+        'thread_1',
+      );
+
+      expect(octokitRequestMock).toHaveBeenCalledTimes(2);
+      expect(octokitConstructorMock).toHaveBeenCalledTimes(2);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'GitHub API mark mailbox thread as read failed on attempt 1',
+        ),
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('does not retry permanent validation failures', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    octokitRequestMock.mockRejectedValueOnce(
+      createOctokitError('Validation Failed', { status: 422 }),
+    );
+
+    try {
+      const client = createGitHubSignalClient();
+      await expect(
+        client.markMailboxThreadAsRead(
+          { ghConfigDir: '/tmp/gh-config-no-retry-validation' },
+          'thread_1',
+        ),
+      ).rejects.toThrow(GitHubRuntimeError);
+
+      expect(octokitRequestMock).toHaveBeenCalledTimes(1);
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('does not retry GraphQL semantic responses without usable data', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    octokitPaginateMock.mockResolvedValueOnce([]);
+    octokitGraphqlMock.mockResolvedValueOnce({
+      errors: [{ message: 'field requires project scope' }],
+    });
+
+    try {
+      const client = createGitHubSignalClient();
+      await expect(
+        client.getSignalSummary(
+          { ghConfigDir: '/tmp/gh-config-no-retry-graphql-semantic' },
+          createConfig(),
+        ),
+      ).rejects.toThrow('GitHub GraphQL response did not include usable data');
+
+      expect(octokitGraphqlMock).toHaveBeenCalledTimes(1);
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
   it('ensureProject accepts raw octokit graphql responses without a data wrapper', async () => {
     const project = createProjectValueNode([]);
 
@@ -1190,32 +1315,53 @@ describe('GitHub mailbox mutations', () => {
 });
 
 describe('GitHub API failure handling', () => {
-  it('maps 401 responses to GitHubAuthError for mailbox listing', async () => {
-    octokitPaginateMock.mockRejectedValueOnce({
+  it('maps exhausted 401 responses to GitHubAuthError for mailbox listing', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    octokitPaginateMock.mockRejectedValue({
       status: 401,
       message: 'Bad credentials',
     });
 
-    const client = createGitHubSignalClient();
+    try {
+      const client = createGitHubSignalClient();
 
-    await expect(
-      client.listMailboxNotifications({ ghConfigDir: '/tmp/gh-config' }),
-    ).rejects.toBeInstanceOf(GitHubAuthError);
+      await expect(
+        client.listMailboxNotifications({
+          ghConfigDir: '/tmp/gh-config-auth-exhaustion',
+        }),
+      ).rejects.toBeInstanceOf(GitHubAuthError);
+
+      expect(octokitPaginateMock).toHaveBeenCalledTimes(3);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('retries exhausted'),
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
-  it('maps rate-limit responses to GitHubRuntimeError', async () => {
-    octokitPaginateMock.mockRejectedValueOnce({
+  it('maps exhausted rate-limit responses to GitHubRuntimeError', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    octokitPaginateMock.mockRejectedValue({
       status: 403,
       message: 'API rate limit exceeded for test user.',
     });
 
-    const client = createGitHubSignalClient();
-    const result = client.listMailboxNotifications({
-      ghConfigDir: '/tmp/gh-config',
-    });
+    try {
+      const client = createGitHubSignalClient();
+      const result = client.listMailboxNotifications({
+        ghConfigDir: '/tmp/gh-config-rate-limit-exhaustion',
+      });
 
-    await expect(result).rejects.toBeInstanceOf(GitHubRuntimeError);
-    await expect(result).rejects.toThrow(/rate limit exceeded/i);
+      await expect(result).rejects.toBeInstanceOf(GitHubRuntimeError);
+      await expect(result).rejects.toThrow(/rate limit exceeded/i);
+      expect(octokitPaginateMock).toHaveBeenCalledTimes(3);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('retries exhausted'),
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   it('fails fast when GraphQL returns errors without usable data', async () => {
@@ -1236,17 +1382,27 @@ describe('GitHub API failure handling', () => {
     );
   });
 
-  it('maps transient network failures to GitHubRuntimeError', async () => {
-    octokitRequestMock.mockRejectedValueOnce({
+  it('maps exhausted transient network failures to GitHubRuntimeError', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    octokitRequestMock.mockRejectedValue({
       code: 'ETIMEDOUT',
       message: 'connect ETIMEDOUT api.github.com:443',
     });
-    const result = resolveMailboxThreadDetail(
-      { ghConfigDir: '/tmp/gh-config' },
-      'thread_1',
-    );
 
-    await expect(result).rejects.toBeInstanceOf(GitHubRuntimeError);
-    await expect(result).rejects.toThrow(/GitHub network error/i);
+    try {
+      const result = resolveMailboxThreadDetail(
+        { ghConfigDir: '/tmp/gh-config-network-exhaustion' },
+        'thread_1',
+      );
+
+      await expect(result).rejects.toBeInstanceOf(GitHubRuntimeError);
+      await expect(result).rejects.toThrow(/GitHub network error/i);
+      expect(octokitRequestMock).toHaveBeenCalledTimes(3);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('retries exhausted'),
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 });

--- a/src/core/github/api.ts
+++ b/src/core/github/api.ts
@@ -96,6 +96,31 @@ function isGitHubNetworkFailure(error: unknown): boolean {
   );
 }
 
+function isGitHubServerFailure(error: unknown): boolean {
+  const status = getGitHubErrorStatus(error);
+
+  return status !== null && status >= 500 && status <= 599;
+}
+
+function isRetryableGitHubApiFailure(
+  error: unknown,
+  allowAuthRetry: boolean,
+): boolean {
+  if (error instanceof GitHubRuntimeError) {
+    return false;
+  }
+
+  if (isGitHubAuthFailure(error)) {
+    return allowAuthRetry;
+  }
+
+  return (
+    isGitHubNetworkFailure(error) ||
+    isGitHubServerFailure(error) ||
+    isGitHubRateLimitFailure(error)
+  );
+}
+
 function toGitHubApiError(
   error: unknown,
 ): GitHubAuthError | GitHubRuntimeError {
@@ -123,6 +148,12 @@ function toGitHubApiError(
 function getApiPathFromUrl(url: string): string {
   const parsed = new URL(url);
   return `${parsed.pathname}${parsed.search}`;
+}
+
+const GITHUB_API_RETRY_DELAYS_MS = [250, 1_000];
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 class OctokitGitHubApiClient implements GitHubApiClient {
@@ -157,15 +188,68 @@ class OctokitGitHubApiClient implements GitHubApiClient {
     throw toGitHubApiError(error);
   }
 
+  private async runWithRetry<T>(
+    paths: Pick<WorkspacePaths, 'ghConfigDir'>,
+    operationName: string,
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    for (let attemptIndex = 0; ; attemptIndex += 1) {
+      try {
+        return await operation();
+      } catch (error) {
+        const attempt = attemptIndex + 1;
+        const hasAuthenticatedClient = this.octokitByConfigDir.has(
+          paths.ghConfigDir,
+        );
+        const retryDelayMs = GITHUB_API_RETRY_DELAYS_MS[attemptIndex];
+        const isRetryable = isRetryableGitHubApiFailure(
+          error,
+          hasAuthenticatedClient,
+        );
+        const shouldRetry = retryDelayMs !== undefined && isRetryable;
+
+        if (isGitHubAuthFailure(error)) {
+          this.octokitByConfigDir.delete(paths.ghConfigDir);
+        }
+
+        if (!shouldRetry) {
+          if (isRetryable) {
+            console.warn(
+              `GitHub API ${operationName} failed after ${attempt} attempts; retries exhausted: ${extractGitHubErrorMessage(
+                error,
+              )}`,
+            );
+          }
+
+          throw error;
+        }
+
+        const nextAttempt = attempt + 1;
+        console.warn(
+          `GitHub API ${operationName} failed on attempt ${attempt}; retrying in ${retryDelayMs}ms (attempt ${nextAttempt} of ${
+            GITHUB_API_RETRY_DELAYS_MS.length + 1
+          }): ${extractGitHubErrorMessage(error)}`,
+        );
+        await sleep(retryDelayMs);
+      }
+    }
+  }
+
   async listUnreadNotifications(
     paths: Pick<WorkspacePaths, 'ghConfigDir'>,
   ): Promise<NotificationThread[]> {
     try {
-      const octokit = await this.getOctokit(paths);
+      return await this.runWithRetry(
+        paths,
+        'list unread notifications',
+        async () => {
+          const octokit = await this.getOctokit(paths);
 
-      return (await octokit.paginate('GET /notifications', {
-        per_page: 100,
-      })) as NotificationThread[];
+          return (await octokit.paginate('GET /notifications', {
+            per_page: 100,
+          })) as NotificationThread[];
+        },
+      );
     } catch (error) {
       this.handleError(paths, error);
     }
@@ -176,9 +260,14 @@ class OctokitGitHubApiClient implements GitHubApiClient {
     threadId: string,
   ): Promise<NotificationThread> {
     try {
-      const octokit = await this.getOctokit(paths);
-      const response = await octokit.request(
-        `GET /notifications/threads/${threadId}`,
+      const response = await this.runWithRetry(
+        paths,
+        'get notification thread',
+        async () => {
+          const octokit = await this.getOctokit(paths);
+
+          return octokit.request(`GET /notifications/threads/${threadId}`);
+        },
       );
 
       return response.data as NotificationThread;
@@ -192,8 +281,15 @@ class OctokitGitHubApiClient implements GitHubApiClient {
     url: string,
   ): Promise<NotificationSubjectResource> {
     try {
-      const octokit = await this.getOctokit(paths);
-      const response = await octokit.request(`GET ${getApiPathFromUrl(url)}`);
+      const response = await this.runWithRetry(
+        paths,
+        'get notification resource',
+        async () => {
+          const octokit = await this.getOctokit(paths);
+
+          return octokit.request(`GET ${getApiPathFromUrl(url)}`);
+        },
+      );
 
       return response.data as NotificationSubjectResource;
     } catch (error) {
@@ -206,9 +302,15 @@ class OctokitGitHubApiClient implements GitHubApiClient {
     threadId: string,
   ): Promise<void> {
     try {
-      const octokit = await this.getOctokit(paths);
+      await this.runWithRetry(
+        paths,
+        'mark mailbox thread as read',
+        async () => {
+          const octokit = await this.getOctokit(paths);
 
-      await octokit.request(`PATCH /notifications/threads/${threadId}`);
+          await octokit.request(`PATCH /notifications/threads/${threadId}`);
+        },
+      );
     } catch (error) {
       this.handleError(paths, error);
     }
@@ -220,8 +322,11 @@ class OctokitGitHubApiClient implements GitHubApiClient {
     variables: Record<string, string> = {},
   ): Promise<T> {
     try {
-      const octokit = await this.getOctokit(paths);
-      const response = await octokit.graphql<unknown>(query, variables);
+      const response = await this.runWithRetry(paths, 'graphql', async () => {
+        const octokit = await this.getOctokit(paths);
+
+        return octokit.graphql<unknown>(query, variables);
+      });
 
       if (
         typeof response === 'object' &&

--- a/src/core/github/api.ts
+++ b/src/core/github/api.ts
@@ -209,6 +209,7 @@ class OctokitGitHubApiClient implements GitHubApiClient {
         const shouldRetry = retryDelayMs !== undefined && isRetryable;
 
         if (isGitHubAuthFailure(error)) {
+          // Drop only the in-memory Octokit instance so a retry asks gh for a fresh token.
           this.octokitByConfigDir.delete(paths.ghConfigDir);
         }
 


### PR DESCRIPTION
## Background

#42 tracks the monitor/sleep loop stopping when GitHub polling hits a temporary API or auth-token-looking failure after the agent had already authenticated. Startup auth checks should still fail fast, but API calls inside the running loop need a bounded retry policy before they can terminate the cycle.

## Changes

- Added a shared retry wrapper in `OctokitGitHubApiClient` for notification pagination, notification thread/resource REST reads, mailbox read mutations, and Project GraphQL calls.
- Retryable failures now include network errors, HTTP 5xx, rate-limit / secondary-rate-limit responses, and auth-looking API failures after an Octokit client exists for the workspace.
- Permanent failures such as validation errors and GraphQL semantic responses without usable data remain non-retryable.
- Auth-looking retry attempts invalidate the cached Octokit client so a later attempt can reload the current `gh` token.
- Retry attempts and retry exhaustion emit visible diagnostics through `console.warn`; final failures still surface as the existing `GitHubAuthError` / `GitHubRuntimeError` types.

## Verification

- `npm run test -- src/core/github.test.ts`
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm run ci:verify`

## Risks

- Bounded retries can add up to about 1.25s before surfacing a persistent retryable API failure.
- Permanent mid-loop auth failures now retry twice before surfacing, while startup auth checks remain outside this API retry path and still fail immediately.

Closes #42