### PR TITLE
fix: retry monitor auth polling once

### DIFF
--- a/src/commands/commands.test.ts
+++ b/src/commands/commands.test.ts
@@ -828,6 +828,57 @@ describe('commands', () => {
     expect(await readLockInfo(paths.lockFile)).toBeNull();
   });
 
+  it('runCommand retries an auth-looking failure after monitor polling has succeeded', async () => {
+    const logs = captureConsoleLogs();
+    let signalChecks = 0;
+
+    await initWithCodex({
+      githubClient: createGitHubClientStub(0, 0),
+    });
+    const paths = getWorkspacePaths(getWorkspaceRoot());
+    await writeFile(
+      paths.configFile,
+      JSON.stringify({
+        ...(JSON.parse(await readFile(paths.configFile, 'utf8')) as Record<
+          string,
+          unknown
+        >),
+        pollIntervalMs: 1,
+      }),
+      'utf8',
+    );
+
+    await runCommand(
+      {},
+      {
+        githubClient: {
+          ...createGitHubClientStub(0, 0),
+          async getSignalSummary(_paths, config) {
+            expect(config.projectId).toBe('proj_123');
+            signalChecks += 1;
+
+            if (signalChecks === 2) {
+              throw new GitHubAuthError(
+                'Requires authentication - https://docs.github.com/rest',
+              );
+            }
+
+            return {
+              unreadCount: 0,
+              actionableCount: 0,
+            };
+          },
+        },
+        maxPollCycles: 2,
+      },
+    );
+
+    expect(signalChecks).toBe(3);
+    expect(logs).toContain(
+      'GitHub authentication error during monitor polling; retrying once: Requires authentication - https://docs.github.com/rest',
+    );
+  });
+
   it('runCommand records a session failure and still returns to sleeping mode', async () => {
     const logs = captureConsoleLogs();
 

--- a/src/commands/commands.test.ts
+++ b/src/commands/commands.test.ts
@@ -879,6 +879,63 @@ describe('commands', () => {
     );
   });
 
+  it('runCommand fails when a monitor auth retry also fails', async () => {
+    const logs = captureConsoleLogs();
+    let signalChecks = 0;
+
+    await initWithCodex({
+      githubClient: createGitHubClientStub(0, 0),
+    });
+    const paths = getWorkspacePaths(getWorkspaceRoot());
+    await writeFile(
+      paths.configFile,
+      JSON.stringify({
+        ...(JSON.parse(await readFile(paths.configFile, 'utf8')) as Record<
+          string,
+          unknown
+        >),
+        pollIntervalMs: 1,
+      }),
+      'utf8',
+    );
+
+    await expect(
+      runCommand(
+        {},
+        {
+          githubClient: {
+            ...createGitHubClientStub(0, 0),
+            async getSignalSummary(_paths, config) {
+              expect(config.projectId).toBe('proj_123');
+              signalChecks += 1;
+
+              if (signalChecks >= 2) {
+                throw new GitHubAuthError(
+                  'Requires authentication - https://docs.github.com/rest',
+                );
+              }
+
+              return {
+                unreadCount: 0,
+                actionableCount: 0,
+              };
+            },
+          },
+          maxPollCycles: 2,
+        },
+      ),
+    ).rejects.toMatchObject({
+      message:
+        'GitHub authentication error: Requires authentication - https://docs.github.com/rest',
+      exitCode: 3,
+    });
+
+    expect(signalChecks).toBe(3);
+    expect(logs).toContain(
+      'GitHub authentication error during monitor polling; retrying once after 1ms: Requires authentication - https://docs.github.com/rest',
+    );
+  });
+
   it('runCommand records a session failure and still returns to sleeping mode', async () => {
     const logs = captureConsoleLogs();
 

--- a/src/commands/commands.test.ts
+++ b/src/commands/commands.test.ts
@@ -875,7 +875,7 @@ describe('commands', () => {
 
     expect(signalChecks).toBe(3);
     expect(logs).toContain(
-      'GitHub authentication error during monitor polling; retrying once: Requires authentication - https://docs.github.com/rest',
+      'GitHub authentication error during monitor polling; retrying once after 1ms: Requires authentication - https://docs.github.com/rest',
     );
   });
 

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -84,6 +84,27 @@ function parseIsoDate(value: string | null | undefined): Date | null {
   return Number.isNaN(timestamp.getTime()) ? null : timestamp;
 }
 
+async function getSignalSummaryForMonitorPoll(
+  githubClient: GitHubSignalClient,
+  paths: { ghConfigDir: string },
+  config: Parameters<GitHubSignalClient['getSignalSummary']>[1],
+  hasCompletedSignalPoll: boolean,
+): Promise<Awaited<ReturnType<GitHubSignalClient['getSignalSummary']>>> {
+  try {
+    return await githubClient.getSignalSummary(paths, config);
+  } catch (error) {
+    if (!(error instanceof GitHubAuthError) || !hasCompletedSignalPoll) {
+      throw error;
+    }
+
+    console.log(
+      `GitHub authentication error during monitor polling; retrying once: ${error.message}`,
+    );
+
+    return githubClient.getSignalSummary(paths, config);
+  }
+}
+
 function selectRecentUpdatedTaskCards(
   tasks: Array<{
     id: string;
@@ -176,6 +197,7 @@ export async function runCommand(
     let interruptPollSleep: (() => void) | null = null;
     let githubUsername: string | null = null;
     let githubName: string | null = null;
+    let hasCompletedSignalPoll = false;
 
     const stopHandler = () => {
       if (!hasLoggedStop) {
@@ -209,7 +231,13 @@ export async function runCommand(
       while (!shouldStop) {
         const now = new Date();
         const previousAgentMode = state.currentMode;
-        const signals = await githubClient.getSignalSummary(paths, config);
+        const signals = await getSignalSummaryForMonitorPoll(
+          githubClient,
+          paths,
+          config,
+          hasCompletedSignalPoll,
+        );
+        hasCompletedSignalPoll = true;
         state = recordNotificationPoll(state, now);
         await saveSessionState(paths, state);
 

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -84,6 +84,14 @@ function parseIsoDate(value: string | null | undefined): Date | null {
   return Number.isNaN(timestamp.getTime()) ? null : timestamp;
 }
 
+async function waitForMonitorPollInterval(
+  pollIntervalMs: number,
+): Promise<void> {
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, pollIntervalMs);
+  });
+}
+
 async function getSignalSummaryForMonitorPoll(
   githubClient: GitHubSignalClient,
   paths: { ghConfigDir: string },
@@ -98,8 +106,10 @@ async function getSignalSummaryForMonitorPoll(
     }
 
     console.log(
-      `GitHub authentication error during monitor polling; retrying once: ${error.message}`,
+      `GitHub authentication error during monitor polling; retrying once after ${config.pollIntervalMs}ms: ${error.message}`,
     );
+
+    await waitForMonitorPollInterval(config.pollIntervalMs);
 
     return githubClient.getSignalSummary(paths, config);
   }


### PR DESCRIPTION
## Why

Issue #42 has concrete runtime output where an already-running sleeping loop repeatedly reports `Signals: unread=0 actionable=0 shouldWake=false`, then exits on `GitHub authentication error: Requires authentication - https://docs.github.com/rest`. The owner asked for a smaller proposal than PR #43 because that PR changed the shared GitHub API client broadly.

This PR is the minimized alternative: it only changes the `gh-agent run` monitor polling path that produced the observed output.

Fixes #42.

## What Changed

- Retry `getSignalSummary` once when it throws `GitHubAuthError` after at least one successful monitor poll in the same `run` session.
- Keep startup / first-poll auth failures immediate and user-visible.
- Add a regression test using the exact observed message: `Requires authentication - https://docs.github.com/rest`.

## Scope Compared With #43

- No shared `OctokitGitHubApiClient` retry helper.
- No REST/GraphQL/rate-limit/network retry policy changes.
- No token-cache eviction behavior changes.
- Only the sleeping monitor poll path gets a one-time recovery attempt.

## Verification

- `npm run test -- src/commands/commands.test.ts`
- `npm run format:check`
- `npm run ci:verify`

## Risk

This is narrower than #43. It can recover the reported loop-polling auth blip, but it does not cover transient failures in other mailbox/task GitHub API calls. Those broader retry semantics remain outside this minimized PR.